### PR TITLE
Automagic splitting of large block blob uploads. 

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -1302,7 +1302,8 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
             $counter   = 0;
             $body      = '';
             $blockIds  = array();
-            $blockSize = 4194304; // 4mb
+            // if threshold is lower than 4mb, honor threshold, else use 4mb
+            $blockSize = ($this->_SingleBlobUploadThresholdInBytes < 4194304) ? $this->_SingleBlobUploadThresholdInBytes : 4194304;
             while(!$end) {
                 if (is_resource($content)) {
                     $body = fread($content, $blockSize);


### PR DESCRIPTION
I was frustrated to learn that the library didn't handle the auto splitting of the block blobs. It didn't even complain in a useful manner when it would failed. So now, we get the same settings as the C# library on when to auto split, and then to auto split. Also this reduces the amount of memory in use when uploading larger files by only reading as much as needed(4mb) at a time to post to the block.

There are a couple parts that I think need scrutiny and they are;
Hunk 2, where we set the SingleBlobUploadThresholdBytes when out of range. I just the closer default.
Return type for commitBlobBlocks. I changed it to allow the same results to be returned for createBlockBlob. I don't think it to be too much of a problem since it didn't return anything previously.
