### PR TITLE
Drop __clone Implementation

### DIFF
--- a/WindowsAzure/Blob/Models/BlobProperties.php
+++ b/WindowsAzure/Blob/Models/BlobProperties.php
@@ -159,27 +159,6 @@ class BlobProperties
         
         return $result;
     }
-    
-    /**
-     * Makes deep copy from the current object.
-     * 
-     * @return BlobProperties
-     */
-    public function __clone()
-    {
-        $this->_blobType        = $this->_blobType;
-        $this->_cacheControl    = $this->_cacheControl;
-        $this->_contentEncoding = $this->_contentEncoding;
-        $this->_contentLanguage = $this->_contentLanguage;
-        $this->_contentLength   = $this->_contentLength;
-        $this->_contentMD5      = $this->_contentMD5;
-        $this->_contentRange    = $this->_contentRange;
-        $this->_contentType     = $this->_contentType;
-        $this->_etag            = $this->_etag;
-        $this->_lastModified    = $this->_lastModified;
-        $this->_leaseStatus     = $this->_leaseStatus;
-        $this->_sequenceNumber  = $this->_sequenceNumber;
-    }
 
     /**
      * Gets blob lastModified.


### PR DESCRIPTION
The behavior in this __clone implementation is the existing PHP implied execution.

The `__clone` function is used to prepare the object to be copied, for removing values or preparing them as needed before the copy. by default all properties are copied.

http://nl1.php.net/clone
