### PR TITLE
Fixed pear vendor name.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "pear-pear/HTTP_Request2":   "*",
-        "pear-pear/Mail_Mime":       "*",
-        "pear-pear/Mail_mimeDecode": "*"
+        "pear-pear.php.net/HTTP_Request2":   "*",
+        "pear-pear.php.net/Mail_Mime":       "*",
+        "pear-pear.php.net/Mail_mimeDecode": "*"
     },
     
     "repositories": [


### PR DESCRIPTION
Use pear-pear-php.net as vendor name when installing pear packages through composer.
