### PR TITLE
Edit bad str_pad use

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -1320,7 +1320,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                     }
                 }
                 $block = new Block();
-                $block->setBlockId(base64_encode(str_pad($counter++, '0', 6)));
+                $block->setBlockId(base64_encode(str_pad($counter++, 6, '0')));
                 $block->setType('Uncommitted');
                 array_push($blockIds, $block);
                 $this->createBlobBlock($container, $blob, $block->getBlockId(), $body);


### PR DESCRIPTION
Allow upload of >4Gb files
http://msdn.microsoft.com/en-us/library/azure/ee691964.aspx : 
Block IDs are strings of equal length within a blob. Block client code usually uses base-64 encoding to normalize strings into equal lengths. When using base-64 encoding, the pre-encoded string must be 64 bytes or less. Block ID values can be duplicated in different blobs. A blob can have up to 100,000 uncommitted blocks, but their total size cannot exceed 400 GB.

http://php.net/manual/fr/function.str-pad.php
