### PR TITLE
Fixed pear vendor name for composer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,9 +10,9 @@
         }
     ],
     "require": {
-        "pear-pear/HTTP_Request2":   "*",
-        "pear-pear/Mail_Mime":       "*",
-        "pear-pear/Mail_mimeDecode": "*"
+        "pear-pear2.php.net/HTTP_Request2":   "*",
+        "pear-pear2.php.net/Mail_Mime":       "*",
+        "pear-pear2.php.net/Mail_mimeDecode": "*"
     },
     
     "repositories": [


### PR DESCRIPTION
Since this is a minor fix I expect Azure team to merge this without demanding a signed CLA document. Or just fix it yourself without merging.
Ref: https://getcomposer.org/doc/05-repositories.md#pear