### PR TITLE
Change composer's dependencies from obsolete Pear to Composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,17 +10,10 @@
         }
     ],
     "require": {
-        "pear-pear2.php.net/HTTP_Request2":   "*",
-        "pear-pear2.php.net/Mail_Mime":       "*",
-        "pear-pear2.php.net/Mail_mimeDecode": "*"
+        "pear/http_request2":   "dev-master",
+        "pear/mail_mime":       "dev-master",
+        "pear/mail_mime-decode": "dev-master"
     },
-    
-    "repositories": [
-        {
-            "type": "pear",
-            "url": "http://pear.php.net"
-        }
-    ],
     
     "autoload": {
         "psr-0": { "WindowsAzure\\": "" }


### PR DESCRIPTION
Because lot of modern commercial webhostings supports Composer deploy, but disallow instalation old-way based Pear installation, is time to replace Pear with Composer.

`dev-master` version level is suggested because:
 1. Composer's perception of `dev-master` is similiar to Pear's `*` version mark.
 2. [pear/Mail_Mime](https://github.com/pear/Mail_Mime) package have not defined any stable version inside source repository.