### PR TITLE
Don't send Expect: 100-continue header

### DIFF
--- a/WindowsAzure/Common/Internal/Http/HttpClient.php
+++ b/WindowsAzure/Common/Internal/Http/HttpClient.php
@@ -101,7 +101,10 @@ class HttpClient implements IHttpClient
             null, null, $config
         );
 
-        $this->setHeader('user-agent', null);
+        $this->setHeaders(array(
+            "user-agent" => null,
+            "expect" => ''
+        ));
         
         $this->_requestUrl          = null;
         $this->_response            = null;


### PR DESCRIPTION
HTTP_Request2 will send an Expect: 100-continue header if the request body is greater than a certain size. If a request fails and is caught, the socket is in an unusable state and will time-out on future requests. Setting except to an empty string ensures that the request body is always sent on a request.