### PR TITLE
Correct parameters to str_pad

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -1348,7 +1348,7 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                     }
                 }
                 $block = new Block();
-                $block->setBlockId(base64_encode(str_pad($counter++, '0', 6)));
+                $block->setBlockId(base64_encode(str_pad($counter++, 6, '0')));
                 $block->setType('Uncommitted');
                 array_push($blockIds, $block);
                 $this->createBlobBlock($container, $blob, $block->getBlockId(), $body);


### PR DESCRIPTION
The parameters to str_pad were the wrong way round; see: https://secure.php.net/str_pad

This would cause failures if there were more than 9 blocks. Up until then, the failure was masked.