### PR TITLE
Fix HTTP_Request2 and Net_URL2 Composer issues

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,6 +23,6 @@
         "psr-0": { "WindowsAzure\\": "" }
     },
 	"include-path": [
-		"../pear/http_request2"
+		"../../pear/http_request2"
 	]
 }

--- a/composer.json
+++ b/composer.json
@@ -21,5 +21,8 @@
     },
     "autoload": {
         "psr-0": { "WindowsAzure\\": "" }
-    }
+    },
+	"include-path": [
+		"../pear/http_request2"
+	]
 }

--- a/composer.json
+++ b/composer.json
@@ -11,6 +11,7 @@
     ],
     "require": {
         "pear/http_request2": "^2.2",
+        "pear/net_url2": "<2.2",
         "pear/mail_mime": "^1.10",
         "pear/mail_mime-decode": "^1.5",
         "firebase/php-jwt": "^3.0"


### PR DESCRIPTION
This *should* resolve the issues with the merged PR from earlier today. There are 2 issues with the current dependencies:

1. HTTP_Request2 requires Net_URL2, however its version requirement for it is too greedy such that it pulls in Net_URL2 version 2.2 which uses a classmap autoloader that HTTP_Request2 does not support in any version other than dev-master.
2. HTTP_Request2 does not add its include-path in its composer.json in any version other than dev-master

1 is fixed by forcing the version of Net_URL2 to be < 2.2 which doesn't use a classmap autoloader
2 is fixed by a hack that adds the http_request2 to our own include-path