### PR TITLE
Add new function, getAssetListByParams to WindowsAzure\MediaServices\…

### DIFF
--- a/WindowsAzure/MediaServices/MediaServicesRestProxy.php
+++ b/WindowsAzure/MediaServices/MediaServicesRestProxy.php
@@ -426,6 +426,32 @@ class MediaServicesRestProxy extends ServiceRestProxy implements IMediaServices
     }
 
     /**
+    * Get asset list by params
+    *
+    * @param array of parameters to be added to request URL as query string
+    * such as $skip, $filter, $top, and so on
+    * 
+    * @return array of Models\Asset
+    */
+    public function getAssetListByParams($params)
+    {
+
+        $p = array();
+        foreach($params as $k => $v){
+            $p[] = $k.'='.$v;
+        }
+        $paramstr = implode('&', $p);
+        $propertyList = $this->_getEntityList("Assets()?" . $paramstr );
+        $result       = array();
+
+        foreach ($propertyList as $properties) {
+            $result[] = Asset::createFromOptions($properties);
+        }
+
+        return $result;
+    }
+
+    /**
      * Get asset locators
      *
      * @param WindowsAzure\MediaServices\Models\Asset|string $asset Asset data or


### PR DESCRIPTION
I added the following new function (getAssetListByParams) to  WindowsAzure\MediaServices\MediaServicesRestProxy.php.  I added this because the user of azure-sdk-for-php strongly needed this in order to give filter/sort/top params in getting asset list.

Please review this and consider to add to master.

    /**
    * Get asset list by params
    *
    * @param array of parameters to be added to request URL as query string
    * such as $skip, $filter, $top, and so on
    *
    * @return array of Models\Asset
    */
    public function getAssetListByParams($params)
    {

        $p = array();
        foreach($params as $k => $v){
            $p[] = $k.'='.$v;
        }
        $paramstr = implode('&', $p);
        $propertyList = $this->_getEntityList("Assets()?" . $paramstr );
        $result       = array();

        foreach ($propertyList as $properties) {
            $result[] = Asset::createFromOptions($properties);
        }

        return $result;
    }

[Added - Dec 29, 2015]
Here are sample codes for this function:
https://gist.github.com/yokawasa/2c85cec276e43c68fe71
https://gist.github.com/yokawasa/90a8370a4c51c930a301
https://gist.github.com/yokawasa/4eab95e7ef2dc06594ad
