### PR TITLE
Add `extra.branch-alias` setting to `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,12 @@
     "autoload": {
         "psr-0": { "WindowsAzure\\": "" }
     },
-	"include-path": [
-		"../../pear/http_request2"
-	]
+    "include-path": [
+        "../../pear/http_request2"
+    ],
+    "extra": {
+        "branch-alias": {
+            "dev-master": "0.4-dev"
+        }
+    }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "fe1fc6c1372642c9713584951ce4b6d2",
-    "content-hash": "484f68ace63058a6eb2170263d531132",
+    "hash": "7f6e2f78484a177b1ea31a1782aac3e6",
+    "content-hash": "04ae245abe307f37f689996f0fd45263",
     "packages": [
         {
             "name": "firebase/php-jwt",


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Bug fix?      | no
| New feature?  | no
| BC breaks?    | no
| Deprecations? | no
| Tests pass?   | yes
| Fixed tickets |
| License       | MIT
| Doc PR        |

Add `extra.branch-alias` setting to `composer.json` in order to allow install
development versions while respecting [semver](http://semver.org/).
This obviously can be updated taking into account the current branching/release
strategy, maybe the branch alias should be pointing to `0.5-dev` instead of
`0.4-dev`.
This change allows to use constraints like `"microsoft/windowsazure": "^0.4@dev",
which will actually install the `dev-master` version.