### PR TITLE
Failed to save the file with the filesize multiple of 4194304 bytes and larger then 33554432 bytes

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -1347,11 +1347,13 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
                         $content = substr_replace($content, '', 0, $blockSize);
                     }
                 }
-                $block = new Block();
-                $block->setBlockId(base64_encode(str_pad($counter++, '0', 6)));
-                $block->setType('Uncommitted');
-                array_push($blockIds, $block);
-                $this->createBlobBlock($container, $blob, $block->getBlockId(), $body);
+                if (!empty($body)) {
+                    $block = new Block();
+                    $block->setBlockId(base64_encode(str_pad($counter++, '0', 6)));
+                    $block->setType('Uncommitted');
+                    array_push($blockIds, $block);
+                    $this->createBlobBlock($container, $blob, $block->getBlockId(), $body);
+                }
             }
             $response = $this->commitBlobBlocks($container, $blob, $blockIds, $options);
         }


### PR DESCRIPTION
Hello. I have a file with size 75497472 bytes. I was trying to download file to azure blob storage by createBlockBlob function (master branch, file was sent like a file stream) and got next Exception:

`Code: 400
Value: The value for one of the HTTP headers is not in the correct format.
details (if any): ﻿<?xml version="1.0" encoding="utf-8"?><Error><Code>InvalidHeaderValue</Code><Message>The value for one of the HTTP headers is not in the correct format.
RequestId:XXXX
Time:2016-01-29T20:10:07.8717460Z</Message><HeaderName>Content-Length</HeaderName><HeaderValue>0</HeaderValue></Error>.`

After debugging this problem I have found an error place: an empty $body variable after fread
BlobRestProxy.php:1337   `$body = fread($content, $blockSize);`

You have no check about empty $body on executing
BlobRestProxy.php:1355:  `$this->createBlobBlock($container, $blob, $block->getBlockId(), $body);`

And it cause such error after last part of file.

The reason is next: when you upload to storage last part of file it doesn't have feof flag set because  fread get exactly that count of bytes that was requested. So we have next loop cycle on which fread gets 0 bytes and feof flag is true. And that is an error situation.

One of possible solutions is just to check $body to be not empty.