### PR TITLE
Fixed PHP 5.3 compatibility issues in the MediaServices namespace

### DIFF
--- a/WindowsAzure/MediaServices/MediaServicesRestProxy.php
+++ b/WindowsAzure/MediaServices/MediaServicesRestProxy.php
@@ -2876,7 +2876,7 @@ class MediaServicesRestProxy extends ServiceRestProxy implements IMediaServices
         );
         $contentKeyId = urlencode($contentKeyId);
         
-        $body        = json_encode(['keyDeliveryType' => $contentKeyDeliveryType]);
+        $body        = json_encode(array('keyDeliveryType' => $contentKeyDeliveryType));
 
         $method      = Resources::HTTP_POST;
         $path        = "ContentKeys('{$contentKeyId}')/GetKeyDeliveryUrl";

--- a/WindowsAzure/MediaServices/Models/AssetFile.php
+++ b/WindowsAzure/MediaServices/Models/AssetFile.php
@@ -173,7 +173,7 @@ class AssetFile
      * @return string[]
      */
     public function requiredFields() {
-        return ['Name', 'ParentAssetId'];
+        return array('Name', 'ParentAssetId');
     }
 
     /**


### PR DESCRIPTION
Replaced short array syntax to the long one.
Just for reference: http://php.net/manual/en/migration54.new-features.php
Tested on our application, which consumes MediaServices part of the API and only implements read access to media files.
