### PR TITLE
https://github.com/Azure/azure-sdk-for-php/issues/756

### DIFF
--- a/WindowsAzure/Table/Internal/AtomReaderWriter.php
+++ b/WindowsAzure/Table/Internal/AtomReaderWriter.php
@@ -241,7 +241,7 @@ class AtomReaderWriter implements IAtomReaderWriter
             
             $entity->addProperty(
                 (string)$key,
-                is_null($type) ? null : (string)$type,
+                is_null($type) ? EdmType::STRING : (string)$type,
                 $isnull ? null : $value
             );
         }


### PR DESCRIPTION
Null is being returned from the server when the type is string. As in http://azure.github.io/azure-sdk-for-java/com/microsoft/azure/storage/table/EdmType.html, null type will be matched to string.