### PR TITLE
Fix the extra / that can be appended.

### DIFF
--- a/WindowsAzure/Blob/BlobRestProxy.php
+++ b/WindowsAzure/Blob/BlobRestProxy.php
@@ -194,7 +194,11 @@ class BlobRestProxy extends ServiceRestProxy implements IBlob
             $encodedBlob = $container . '/' . $encodedBlob;
         }
         
-        return $this->getUri() . '/' . $encodedBlob;
+        if (substr($encodedBlob, 0, 1) != '/' && substr($this->getUri(), -1, 1) != '/')
+        {
+            $encodedBlob =  '/' .  $encodedBlob;
+        }
+        return $this->getUri() . $encodedBlob;
     }
     
     /**


### PR DESCRIPTION
Sometimes $this->getUri() will already have a trailing / which will cause the result URL to have //.