### PR TITLE
Remove hard-coded require-once statements for PEAR packages

### DIFF
--- a/WindowsAzure/Common/Internal/Http/BatchRequest.php
+++ b/WindowsAzure/Common/Internal/Http/BatchRequest.php
@@ -23,8 +23,6 @@
  */
 
 namespace WindowsAzure\Common\Internal\Http;
-require_once 'PEAR.php';
-require_once 'Mail/mimePart.php';
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Utilities;
 

--- a/WindowsAzure/Common/Internal/Http/BatchResponse.php
+++ b/WindowsAzure/Common/Internal/Http/BatchResponse.php
@@ -23,9 +23,6 @@
  */
 
 namespace WindowsAzure\Common\Internal\Http;
-require_once 'PEAR.php';
-require_once 'Mail/mimeDecode.php';
-require_once 'HTTP/Request2/Response.php';
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Validate;
 use WindowsAzure\Common\ServiceException;

--- a/WindowsAzure/Common/Internal/Http/HttpClient.php
+++ b/WindowsAzure/Common/Internal/Http/HttpClient.php
@@ -30,8 +30,6 @@ use WindowsAzure\Common\ServiceException;
 use WindowsAzure\Common\Internal\Validate;
 use WindowsAzure\Common\Internal\Http\IUrl;
 
-require_once 'HTTP/Request2.php';
-
 /**
  * HTTP client which sends and receives HTTP requests and responses.
  *

--- a/WindowsAzure/Common/Internal/Http/Url.php
+++ b/WindowsAzure/Common/Internal/Http/Url.php
@@ -23,7 +23,6 @@
  */
  
 namespace WindowsAzure\Common\Internal\Http;
-require_once 'Net/URL2.php';
 use WindowsAzure\Common\Internal\Validate;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Http\IUrl;

--- a/WindowsAzure/Table/Internal/MimeReaderWriter.php
+++ b/WindowsAzure/Table/Internal/MimeReaderWriter.php
@@ -23,9 +23,6 @@
  */
  
 namespace WindowsAzure\Table\Internal;
-require_once 'PEAR.php';
-require_once 'Mail/mimePart.php';
-require_once 'Mail/mimeDecode.php';
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Utilities;
 

--- a/WindowsAzure/Table/Models/BatchResult.php
+++ b/WindowsAzure/Table/Models/BatchResult.php
@@ -23,7 +23,6 @@
  */
  
 namespace WindowsAzure\Table\Models;
-require_once 'HTTP/Request2/Response.php';
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Utilities;
 use WindowsAzure\Common\Internal\Http\HttpClient;


### PR DESCRIPTION
Remove hard-coded require-once statements for PEAR packages, not needed for Composer and actually can cause problems. 