### PR TITLE
Update PEAR dependencies 

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
     ],
     "require": {
         "php": ">=5.4",
-        "pear/http_request2": "^2.2",
-        "pear/net_url2": "<2.2",
+        "pear/http_request2": "^2.3",
+        "pear/net_url2": "^2.2",
         "pear/mail_mime": "^1.10",
         "pear/mail_mime-decode": "^1.5",
         "firebase/php-jwt": "^3.0"
@@ -24,9 +24,6 @@
     "autoload": {
         "psr-0": { "WindowsAzure\\": "" }
     },
-    "include-path": [
-        "./vendor/pear/http_request2"
-    ],
     "extra": {
         "branch-alias": {
             "dev-master": "0.4-dev"

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "a30fee1145a86ae4c699e132e21d8de6",
-    "content-hash": "24b51d4867e55091dc9e7f9dfe7f5595",
+    "hash": "932aca5cd3a55b4b0c6d04a5e7bb18ed",
+    "content-hash": "d6243e280af35b8f85920e9e2edef4d5",
     "packages": [
         {
             "name": "firebase/php-jwt",
@@ -99,21 +99,21 @@
         },
         {
             "name": "pear/http_request2",
-            "version": "v2.2.1",
+            "version": "v2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/HTTP_Request2.git",
-                "reference": "d6c81670c504045248c1afdf896bb9a3288158de"
+                "reference": "3599cf0fe455a4e281da464f6510bfc5c2ce54c4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/d6c81670c504045248c1afdf896bb9a3288158de",
-                "reference": "d6c81670c504045248c1afdf896bb9a3288158de",
+                "url": "https://api.github.com/repos/pear/HTTP_Request2/zipball/3599cf0fe455a4e281da464f6510bfc5c2ce54c4",
+                "reference": "3599cf0fe455a4e281da464f6510bfc5c2ce54c4",
                 "shasum": ""
             },
             "require": {
-                "pear/net_url2": ">=2.0.0",
-                "pear/pear_exception": "*",
+                "pear/net_url2": "^2.2.0",
+                "pear/pear_exception": "^1.0.0",
                 "php": ">=5.2.0"
             },
             "suggest": {
@@ -123,20 +123,27 @@
                 "lib-openssl": "Allows handling SSL requests when not using cURL."
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-trunk": "2.2-dev"
+                }
+            },
             "autoload": {
                 "psr-0": {
                     "HTTP_Request2": ""
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
+            "include-path": [
+                "./"
+            ],
             "license": [
                 "BSD-3-Clause"
             ],
             "authors": [
                 {
                     "name": "Alexey Borzov",
-                    "email": "avb@php.net",
-                    "role": "Developer HTML_Common2"
+                    "email": "avb@php.net"
                 }
             ],
             "description": "Provides an easy way to perform HTTP requests.",
@@ -147,7 +154,7 @@
                 "http",
                 "request"
             ],
-            "time": "2014-01-16 17:27:21"
+            "time": "2016-02-13 20:20:39"
         },
         {
             "name": "pear/mail_mime",
@@ -245,16 +252,16 @@
         },
         {
             "name": "pear/net_url2",
-            "version": "v2.1.1",
+            "version": "v2.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pear/Net_URL2.git",
-                "reference": "cfd234e8484400a122cec44a9d801e71186915ac"
+                "reference": "fa9b1ecb3c3e640d4a54d58d681a4cb7524f209e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pear/Net_URL2/zipball/cfd234e8484400a122cec44a9d801e71186915ac",
-                "reference": "cfd234e8484400a122cec44a9d801e71186915ac",
+                "url": "https://api.github.com/repos/pear/Net_URL2/zipball/fa9b1ecb3c3e640d4a54d58d681a4cb7524f209e",
+                "reference": "fa9b1ecb3c3e640d4a54d58d681a4cb7524f209e",
                 "shasum": ""
             },
             "require": {
@@ -266,18 +273,15 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.0.x-dev"
+                    "dev-master": "2.2.x-dev"
                 }
             },
             "autoload": {
-                "psr-0": {
-                    "Net": ""
-                }
+                "classmap": [
+                    "Net/URL2.php"
+                ]
             },
             "notification-url": "https://packagist.org/downloads/",
-            "include-path": [
-                "./"
-            ],
             "license": [
                 "BSD-3-Clause"
             ],
@@ -305,7 +309,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2014-12-27 14:00:16"
+            "time": "2015-04-18 17:36:57"
         },
         {
             "name": "pear/pear-core-minimal",


### PR DESCRIPTION
The current version of composer.json removed a hack that I implemented in #764 to fix HTTP_Request2 and Net_URL2 autoloading (HTTP_Request2 did not supply the proper include_path and Net_URL2 switched to a classmap autoloader which HTTP_Request2 did not update to support) which which was broken in the most recent HTTP_Request2 version at the time. They have since released a new version which addresses these issues, so I updated the dependencies to remove the need for that hack.

For some more info, the reason why the include-path was originally `../../pear/http_request2` was because if this project was used as a library in the vendor directory, that would be the relative path for http_request2, whereas if this project was being used standalone, `./vendor/pear/http_request2` would be the proper include-path. Either way, the changes here obviates this and allows the project to be used as a library again.