### PR TITLE
Minor changes in examples\README.markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -551,12 +551,13 @@ try {
 ### Set-up certificates
 
 You  need to create two certificates, one for the server (a .cer file) and one for the client (a .pem file). To create the .pem file using [OpenSSL](http://www.openssl.org), execute this: 
-
-  openssl req -x509 -nodes -days 365 -newkey rsa:1024 -keyout mycert.pem -out mycert.pem
-
+```
+openssl req -x509 -nodes -days 365 -newkey rsa:1024 -keyout mycert.pem -out mycert.pem
+```
 To create the .cer certificate, execute this: 
-
-  openssl x509 -inform pem -in mycert.pem -outform der -out mycert.cer
+```
+openssl x509 -inform pem -in mycert.pem -outform der -out mycert.cer
+```
 
 ### List Available Locations
 

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ try {
 ## Service Bus Queues
 The current PHP Service Bus APIs only support ACS connection strings. You need to use PowerShell to create a new ACS Service Bus namespace at the present time.  
 First, make sure you have Azure PowerShell installed, then in a PowerShell command prompt, run 
-```
+```PowerShell
 Add-AzureAccount # this will sign you in
 New-AzureSBNamespace -CreateACSNamespace $true -Name 'mytestbusname' -Location 'West US' -NamespaceType 'Messaging'
 ```

--- a/examples/README.markdown
+++ b/examples/README.markdown
@@ -46,8 +46,11 @@ see https://azure.microsoft.com/en-us/blog/introducing-the-windows-azure-service
 # Using Fiddler to Debug HTTP/HTTPS Requests
 
 * Install [Fiddler](http://www.telerik.com/fiddler).
+
 * Set the `HTTP_PROXY` enviroment variable to `http://localhost:8888`. For example
+
     ```bat
     set HTTP_PROXY=http://localhost:8888
     ```
+
 * Start your program.


### PR DESCRIPTION
The GitHub MarkDown engine renders `examples\README.markdown` slightly different to Visual Studio Code. For example, see the page [before](https://github.com/Azure/azure-sdk-for-php/blob/master/examples/README.markdown#using-fiddler-to-debug-httphttps-requests) and [after](https://github.com/sergey-shandar/azure-sdk-for-php/tree/sergey-shandar-readme-style/examples#using-fiddler-to-debug-httphttps-requests).
