### PR TITLE
Breaking changes: the getResponse() function from \WindowsAzure\Common\Internal\Http\IHttpClient is replaced by sendAndGetResponse()

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,3 +1,5 @@
+- Breaking changes: the `getResponse()` function from 
+  `\WindowsAzure\Common\Internal\Http\IHttpClient` is replaced by `sendAndGetResponse()`.
 - Switch to PHP 5.6.
 
 Windows Azure SDK For PHP 0.4.5, 2016-09-26

--- a/src/Common/Internal/Http/HttpClient.php
+++ b/src/Common/Internal/Http/HttpClient.php
@@ -92,12 +92,14 @@ class HttpClient implements IHttpClient
         //
         //     set HTTP_PROXY=http://localhost:8888
         //     php my_program.php
-        $proxy = getenv('HTTP_PROXY');
-        if ($proxy) {
-            $proxyStruct = parse_url($proxy);
-            if ($proxyStruct) {
-                $config['proxy_host'] = $proxyStruct['host'];
-                $config['proxy_port'] = $proxyStruct['port'];
+        {
+            $proxy = getenv('HTTP_PROXY');
+            if ($proxy) {
+                $proxyStruct = parse_url($proxy);
+                if ($proxyStruct) {
+                    $config['proxy_host'] = $proxyStruct['host'];
+                    $config['proxy_port'] = $proxyStruct['port'];
+                }
             }
         }
 

--- a/src/Common/Internal/Http/HttpClient.php
+++ b/src/Common/Internal/Http/HttpClient.php
@@ -55,13 +55,6 @@ class HttpClient implements IHttpClient
     private $_requestUrl;
 
     /**
-     * Holds the latest response object.
-     *
-     * @var \HTTP_Request2_Response
-     */
-    private $_response;
-
-    /**
      * Holds expected status code after sending the request.
      *
      * @var array
@@ -122,7 +115,6 @@ class HttpClient implements IHttpClient
         $this->setHeader('expect', '');
 
         $this->_requestUrl = null;
-        $this->_response = null;
         $this->_expectedStatusCodes = array();
     }
 
@@ -281,23 +273,21 @@ class HttpClient implements IHttpClient
             $this->_request = $filter->handleRequest($this)->_request;
         }
 
-        $this->_response = $this->_request->send();
+        $response = $this->_request->send();
 
         $start = count($filters) - 1;
         for ($index = $start; $index >= 0; --$index) {
-            $this->_response = $filters[$index]->handleResponse(
-                $this, $this->_response
-            );
+            $response = $filters[$index]->handleResponse($this, $response);
         }
 
         self::throwIfError(
-            $this->_response->getStatus(),
-            $this->_response->getReasonPhrase(),
-            $this->_response->getBody(),
+            $response->getStatus(),
+            $response->getReasonPhrase(),
+            $response->getBody(),
             $this->_expectedStatusCodes
         );
 
-        return $this->_response;
+        return $response;
     }
 
     /**

--- a/src/Common/Internal/Http/HttpClient.php
+++ b/src/Common/Internal/Http/HttpClient.php
@@ -242,18 +242,18 @@ class HttpClient implements IHttpClient
     }
 
     /**
-     * Processes the reuqest through HTTP pipeline with passed $filters,
+     * Processes the reuqest through HTTP pipeline with passed $filters, 
      * sends HTTP request to the wire and process the response in the HTTP pipeline.
-     *
+     * 
      * @param array $filters HTTP filters which will be applied to the request before
      *                       send and then applied to the response.
      * @param IUrl  $url     Request url.
      *
      * @throws WindowsAzure\Common\ServiceException
-     *
-     * @return string The response body
+     * 
+     * @return \HTTP_Request2_Response The response.
      */
-    public function send($filters, $url = null)
+    public function sendAndGetResponse($filters, $url = null)
     {
         if (isset($url)) {
             $this->setUrl($url);
@@ -297,7 +297,24 @@ class HttpClient implements IHttpClient
             $this->_expectedStatusCodes
         );
 
-        return $this->_response->getBody();
+        return $this->_response;
+    }
+
+    /**
+     * Processes the reuqest through HTTP pipeline with passed $filters,
+     * sends HTTP request to the wire and process the response in the HTTP pipeline.
+     *
+     * @param array $filters HTTP filters which will be applied to the request before
+     *                       send and then applied to the response.
+     * @param IUrl  $url     Request url.
+     *
+     * @throws WindowsAzure\Common\ServiceException
+     *
+     * @return string The response body
+     */
+    public function send($filters, $url = null)
+    {
+        return $this->sendAndGetResponse($filters, $url)->getBody();
     }
 
     /**
@@ -372,16 +389,6 @@ class HttpClient implements IHttpClient
     public function getBody()
     {
         return $this->_request->getBody();
-    }
-
-    /**
-     * Gets the response object.
-     *
-     * @return \HTTP_Request2_Response
-     */
-    public function getResponse()
-    {
-        return $this->_response;
     }
 
     /**

--- a/src/Common/Internal/Http/IHttpClient.php
+++ b/src/Common/Internal/Http/IHttpClient.php
@@ -118,6 +118,18 @@ interface IHttpClient
      *                       send and then applied to the response.
      * @param IUrl  $url     Request url.
      * 
+     * @return \HTTP_Request2_Response The response.
+     */
+    public function sendAndGetResponse($filters, $url = null);
+
+    /**
+     * Processes the reuqest through HTTP pipeline with passed $filters, 
+     * sends HTTP request to the wire and process the response in the HTTP pipeline.
+     * 
+     * @param array $filters HTTP filters which will be applied to the request before
+     *                       send and then applied to the response.
+     * @param IUrl  $url     Request url.
+     * 
      * @return string The response body.
      */
     public function send($filters, $url = null);
@@ -179,13 +191,6 @@ interface IHttpClient
      * @return WindowsAzure\Common\Internal\Http\HttpClient
      */
     public function __clone();
-
-    /**
-     * Gets the response object.
-     * 
-     * @return \HTTP_Request2_Response.
-     */
-    public function getResponse();
 
     /**
      * Throws ServiceException if the recieved status code is not expected.

--- a/src/Common/Internal/RestProxy.php
+++ b/src/Common/Internal/RestProxy.php
@@ -140,9 +140,7 @@ class RestProxy
         $url->setQueryVariables($queryParams);
         $url->appendUrlPath($path);
 
-        $channel->send($this->_filters, $url);
-
-        return $channel->getResponse();
+        return $channel->sendAndGetResponse($this->_filters, $url);
     }
 
     /**

--- a/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
@@ -230,7 +230,7 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
     /**
      * @covers WindowsAzure\Common\Internal\Http\HttpClient::sendAndGetResponse
      */
-    public function testGetResponse()
+    public function testSendAndGetResponse()
     {
         // Setup
         $channel = new HttpClient();

--- a/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
@@ -228,6 +228,23 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
+     * @covers WindowsAzure\Common\Internal\Http\HttpClient::sendAndGetResponse
+     */
+    public function testGetResponse()
+    {
+        // Setup
+        $channel = new HttpClient();
+        $url = new Url('http://example.com/');
+        $channel->setExpectedStatusCode('200');
+        
+        // Test
+        $response = $channel->sendAndGetResponse(array(), $url);
+
+        // Assert
+        $this->assertInstanceOf('\HTTP_Request2_Response', $response);
+    }
+
+    /**
      * @covers WindowsAzure\Common\Internal\Http\HttpClient::send
      */
     public function testSendSimple()
@@ -462,24 +479,6 @@ class HttpClientTest extends \PHPUnit_Framework_TestCase
         // Assert
         $this->assertNotEquals($channel->getHeaders(), $actual->getHeaders());
         $this->assertNotEquals($channel->getUrl()->getUrl(), $actual->getUrl()->getUrl());
-    }
-
-    /**
-     * @covers WindowsAzure\Common\Internal\Http\HttpClient::getResponse
-     */
-    public function testGetResponse()
-    {
-        // Setup
-        $channel = new HttpClient();
-        $url = new Url('http://example.com/');
-        $channel->setExpectedStatusCode('200');
-        $channel->send(array(), $url);
-
-        // Test
-        $response = $channel->getResponse();
-
-        // Assert
-        $this->assertInstanceOf('\HTTP_Request2_Response', $response);
     }
 
     /**


### PR DESCRIPTION
We plan to remove PEAR libraries such as `HTTP_Request2` (Issue #797). So we need to replace functions which return types from the PEAR libraries, such as `HTTP_Request2_Response`. This PR is one of the first steps to do so.