### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "mikey179/vfsStream": "^1.6",
-        "phpunit/phpunit": "^4.8",
+        "phpunit/phpunit": "^4.8.35",
         "phpdocumentor/phpdocumentor": "^2.8",
         "sebastian/phpcpd": "^2.0",
         "phploc/phploc": "^2.1",

--- a/tests/framework/RestProxyTestBase.php
+++ b/tests/framework/RestProxyTestBase.php
@@ -29,6 +29,7 @@ namespace Tests\framework;
 use WindowsAzure\Common\Internal\Logger;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
 use WindowsAzure\Common\ServicesBuilder;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Test base for all REST proxy tests.
@@ -43,7 +44,7 @@ use WindowsAzure\Common\ServicesBuilder;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RestProxyTestBase extends \PHPUnit_Framework_TestCase
+class RestProxyTestBase extends TestCase
 {
     protected $restProxy;
     protected $xmlSerializer;

--- a/tests/unit/WindowsAzure/Common/CloudConfigurationManagerTest.php
+++ b/tests/unit/WindowsAzure/Common/CloudConfigurationManagerTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common;
 
 use WindowsAzure\Common\CloudConfigurationManager;
 use WindowsAzure\Common\Internal\ConnectionStringSource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CloudConfigurationManager.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\ConnectionStringSource;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class CloudConfigurationManagerTest extends \PHPUnit_Framework_TestCase
+class CloudConfigurationManagerTest extends TestCase
 {
     private $_key = 'my_connection_string';
     private $_value = 'connection string value';

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/AtomLinkTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/AtomLinkTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Atom;
 
 
 use WindowsAzure\Common\Internal\Atom\AtomLink;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class AtomLink.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Atom\AtomLink;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class AtomLinkTest extends \PHPUnit_Framework_TestCase
+class AtomLinkTest extends TestCase
 {
     /**
      */

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/CategoryTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/CategoryTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Atom;
 
 use WindowsAzure\Common\Internal\Atom\Category;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Category.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Atom\Category;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class CategoryTest extends \PHPUnit_Framework_TestCase
+class CategoryTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Category::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/ContentTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/ContentTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Atom;
 
 use WindowsAzure\Common\Internal\Atom\Content;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Atom\Content;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ContentTest extends \PHPUnit_Framework_TestCase
+class ContentTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Content::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/EntryTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/EntryTest.php
@@ -31,6 +31,7 @@ use WindowsAzure\Common\Internal\Atom\Entry;
 use WindowsAzure\Common\Internal\Atom\Category;
 use WindowsAzure\Common\Internal\Atom\Person;
 use WindowsAzure\Common\Internal\Atom\Source;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -45,7 +46,7 @@ use WindowsAzure\Common\Internal\Atom\Source;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class EntryTest extends \PHPUnit_Framework_TestCase
+class EntryTest extends TestCase
 {
     /**
      */

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/FeedTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/FeedTest.php
@@ -32,6 +32,7 @@ use WindowsAzure\Common\Internal\Atom\Category;
 use WindowsAzure\Common\Internal\Atom\Person;
 use WindowsAzure\Common\Internal\Atom\Generator;
 use WindowsAzure\Common\Internal\Atom\AtomLink;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Feed.
@@ -46,7 +47,7 @@ use WindowsAzure\Common\Internal\Atom\AtomLink;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class FeedTest extends \PHPUnit_Framework_TestCase
+class FeedTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Feed::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/GeneratorTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/GeneratorTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common\Internal\Atom;
 
 use WindowsAzure\Common\Internal\Atom\Generator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Generator.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\Atom\Generator;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class GeneratorTest extends \PHPUnit_Framework_TestCase
+class GeneratorTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Generator::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/PersonTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/PersonTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common\Internal\Atom;
 
 use WindowsAzure\Common\Internal\Atom\Person;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Person.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\Atom\Person;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class PersonTest extends \PHPUnit_Framework_TestCase
+class PersonTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Person::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Atom/SourceTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Atom/SourceTest.php
@@ -30,6 +30,7 @@ use WindowsAzure\Common\Internal\Atom\Source;
 use WindowsAzure\Common\Internal\Atom\Person;
 use WindowsAzure\Common\Internal\Atom\Generator;
 use WindowsAzure\Common\Internal\Atom\Category;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Source.
@@ -44,7 +45,7 @@ use WindowsAzure\Common\Internal\Atom\Category;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class SourceTest extends \PHPUnit_Framework_TestCase
+class SourceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Atom\Source::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Authentication/SharedKeyAuthSchemeTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Authentication;
 use Tests\mock\WindowsAzure\Common\Internal\Authentication\SharedKeyAuthSchemeMock;
 use WindowsAzure\Common\Internal\Resources;
 use Tests\framework\TestResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for SharedKeyAuthScheme class.
@@ -40,7 +41,7 @@ use Tests\framework\TestResources;
  *
  * @link       https://github.com/windowsazure/azure-sdk-for-php
  */
-class SharedKeyAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class SharedKeyAuthSchemeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Authentication\SharedKeyAuthScheme::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Authentication/StorageAuthSchemeTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Authentication/StorageAuthSchemeTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -29,6 +29,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Authentication;
 use Tests\mock\WindowsAzure\Common\Internal\Authentication\StorageAuthSchemeMock;
 use Tests\framework\TestResources;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for StorageAuthScheme class.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link       https://github.com/windowsazure/azure-sdk-for-php
  */
-class StorageAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class StorageAuthSchemeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Authentication\StorageAuthScheme::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Authentication/TableSharedKeyLiteAuthSchemeTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Authentication/TableSharedKeyLiteAuthSchemeTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Authentication;
 use Tests\mock\WindowsAzure\Common\Internal\Authentication\TableSharedKeyLiteAuthSchemeMock;
 use WindowsAzure\Common\Internal\Resources;
 use Tests\framework\TestResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for TableSharedKeyLiteAuthScheme class.
@@ -40,7 +41,7 @@ use Tests\framework\TestResources;
  *
  * @link       https://github.com/windowsazure/azure-sdk-for-php
  */
-class TableSharedKeyLiteAuthSchemeTest extends \PHPUnit_Framework_TestCase
+class TableSharedKeyLiteAuthSchemeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Authentication\TableSharedKeyLiteAuthScheme::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/ConnectionStringParserTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ConnectionStringParserTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common\Internal;
 
 use WindowsAzure\Common\Internal\ConnectionStringParser;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ConnectionStringParser.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\ConnectionStringParser;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ConnectionStringParserTest extends \PHPUnit_Framework_TestCase
+class ConnectionStringParserTest extends TestCase
 {
     private function _parseTest($connectionString)
     {

--- a/tests/unit/WindowsAzure/Common/Internal/ConnectionStringSourceTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ConnectionStringSourceTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common\Internal;
 
 use WindowsAzure\Common\Internal\ConnectionStringSource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ConnectionStringSource.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\ConnectionStringSource;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ConnectionStringSourceTest extends \PHPUnit_Framework_TestCase
+class ConnectionStringSourceTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/WindowsAzure/Common/Internal/Filters/AuthenticationFilterTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Filters/AuthenticationFilterTest.php
@@ -31,6 +31,7 @@ use WindowsAzure\Common\Internal\Http\Url;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Authentication\SharedKeyAuthScheme;
 use WindowsAzure\MediaServices\Authentication\AccessToken;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class AuthenticationFilterTest.
@@ -45,7 +46,7 @@ use WindowsAzure\MediaServices\Authentication\AccessToken;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AuthenticationFilterTest extends \PHPUnit_Framework_TestCase
+class AuthenticationFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Filters\AuthenticationFilter::handleRequest

--- a/tests/unit/WindowsAzure/Common/Internal/Filters/DateFilterTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Filters/DateFilterTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Filters;
 use WindowsAzure\Common\Internal\Filters\DateFilter;
 use WindowsAzure\Common\Internal\Http\HttpClient;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class DateFilter.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class DateFilterTest extends \PHPUnit_Framework_TestCase
+class DateFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Filters\DateFilter::handleRequest

--- a/tests/unit/WindowsAzure/Common/Internal/Filters/HeadersFilterTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Filters/HeadersFilterTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Filters;
 use WindowsAzure\Common\Internal\Filters\HeadersFilter;
 use WindowsAzure\Common\Internal\Http\HttpClient;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HeadersFilter.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class HeadersFilterTest extends \PHPUnit_Framework_TestCase
+class HeadersFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Filters\HeadersFilter::handleRequest

--- a/tests/unit/WindowsAzure/Common/Internal/Http/BatchRequestTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/BatchRequestTest.php
@@ -26,6 +26,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Http;
 
 use WindowsAzure\Common\Internal\Http\BatchRequest;
 use WindowsAzure\Common\Internal\Http\HttpCallContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HttpCallContext.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\Http\HttpCallContext;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class BatchRequestTest extends \PHPUnit_Framework_TestCase
+class BatchRequestTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Http\batchRequest::appendContext

--- a/tests/unit/WindowsAzure/Common/Internal/Http/BatchResponseTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/BatchResponseTest.php
@@ -28,6 +28,7 @@ use GuzzleHttp\Psr7\Response;
 use WindowsAzure\Common\Internal\Http\BatchResponse;
 use WindowsAzure\Common\Internal\Http\BatchRequest;
 use WindowsAzure\Common\Internal\Http\HttpCallContext;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HttpCallContext.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Http\HttpCallContext;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class BatchResponseTest extends \PHPUnit_Framework_TestCase
+class BatchResponseTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Http\BatchResponse::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Http/HttpCallContextTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/HttpCallContextTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Http;
 
 use WindowsAzure\Common\Internal\Http\HttpCallContext;
 use WindowsAzure\Common\Internal\Http\Url;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HttpCallContext.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Http\Url;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class HttpCallContextTest extends \PHPUnit_Framework_TestCase
+class HttpCallContextTest extends TestCase
 {
     public function test__construct()
     {

--- a/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/HttpClientTest.php
@@ -31,6 +31,7 @@ use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Http\HttpClient;
 use WindowsAzure\Common\Internal\Http\Url;
 use WindowsAzure\Common\ServiceException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HttpClient.
@@ -45,7 +46,7 @@ use WindowsAzure\Common\ServiceException;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class HttpClientTest extends \PHPUnit_Framework_TestCase
+class HttpClientTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Http\HttpClient::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Http/UrlTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Http/UrlTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\Common\Internal\Http\Url;
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\InvalidArgumentTypeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Url.
@@ -43,7 +44,7 @@ use WindowsAzure\Common\Internal\InvalidArgumentTypeException;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class UrlTest extends \PHPUnit_Framework_TestCase
+class UrlTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Http\Url::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/InvalidArgumentTypeExceptionTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/InvalidArgumentTypeExceptionTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common\Internal;
 
 use WindowsAzure\Common\Internal\InvalidArgumentTypeException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class InvalidArgumentTypeException.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\Internal\InvalidArgumentTypeException;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class InvalidArgumentTypeExceptionTest extends \PHPUnit_Framework_TestCase
+class InvalidArgumentTypeExceptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\InvalidArgumentTypeException::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/LoggerTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/LoggerTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal;
 use WindowsAzure\Common\Internal\Logger;
 use WindowsAzure\Common\Internal\Resources;
 use Tests\framework\VirtualFileSystem;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Logger.
@@ -42,7 +43,7 @@ use Tests\framework\VirtualFileSystem;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class LoggerTest extends \PHPUnit_Framework_TestCase
+class LoggerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Logger::log

--- a/tests/unit/WindowsAzure/Common/Internal/MediaServicesSettingsTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/MediaServicesSettingsTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal;
 use WindowsAzure\Common\Internal\MediaServicesSettings;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\MediaServices\Authentication\ITokenProvider;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class MediaServicesSettings.
@@ -42,7 +43,7 @@ use WindowsAzure\MediaServices\Authentication\ITokenProvider;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class MediaServicesSettingsTest extends \PHPUnit_Framework_TestCase
+class MediaServicesSettingsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\MediaServicesSettings::__construct

--- a/tests/unit/WindowsAzure/Common/Internal/Serialization/JsonSerializerTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Serialization/JsonSerializerTest.php
@@ -27,7 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Serialization;
 
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Internal\Serialization\JsonSerializer;
-
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class XmlSerializer.
@@ -42,7 +42,7 @@ use WindowsAzure\Common\Internal\Serialization\JsonSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class JsonSerializerTest extends \PHPUnit_Framework_TestCase
+class JsonSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Serialization\JsonSerializer::objectSerialize

--- a/tests/unit/WindowsAzure/Common/Internal/Serialization/XmlSerializerTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/Serialization/XmlSerializerTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal\Serialization;
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Models\ServiceProperties;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class XmlSerializer.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class XmlSerializerTest extends \PHPUnit_Framework_TestCase
+class XmlSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Serialization\XmlSerializer::unserialize

--- a/tests/unit/WindowsAzure/Common/Internal/ServiceBusSettingsTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ServiceBusSettingsTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal;
 use WindowsAzure\Common\Internal\ServiceBusSettings;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Filters\WrapFilter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ServiceBusSettings.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Filters\WrapFilter;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServiceBusSettingsTest extends \PHPUnit_Framework_TestCase
+class ServiceBusSettingsTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/WindowsAzure/Common/Internal/ServiceManagementSettingsTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ServiceManagementSettingsTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal;
 
 use WindowsAzure\Common\Internal\ServiceManagementSettings;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ServiceManagementSettings.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServiceManagementSettingsTest extends \PHPUnit_Framework_TestCase
+class ServiceManagementSettingsTest extends TestCase
 {
     public function setUp()
     {

--- a/tests/unit/WindowsAzure/Common/Internal/ServiceRestProxyTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ServiceRestProxyTest.php
@@ -32,6 +32,7 @@ use WindowsAzure\Common\Internal\ServiceRestProxy;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Http\HttpClient;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ServiceRestProxy.
@@ -46,7 +47,7 @@ use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServiceRestProxyTest extends \PHPUnit_Framework_TestCase
+class ServiceRestProxyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\ServiceRestProxy::generateMetadataHeaders

--- a/tests/unit/WindowsAzure/Common/Internal/StorageServiceSettingsTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/StorageServiceSettingsTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Internal;
 use WindowsAzure\Common\Internal\StorageServiceSettings;
 use WindowsAzure\Common\Internal\Resources;
 use Tests\Framework\TestResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class StorageServiceSettings.
@@ -42,7 +43,7 @@ use Tests\Framework\TestResources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class StorageServiceSettingsTest extends \PHPUnit_Framework_TestCase
+class StorageServiceSettingsTest extends TestCase
 {
     private $_accountName = 'mytestaccount';
 

--- a/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
@@ -31,6 +31,7 @@ use Tests\Framework\TestResources;
 use WindowsAzure\Common\Models\ServiceProperties;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
 use WindowsAzure\MediaServices\Models\Asset;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Utilities.
@@ -45,7 +46,7 @@ use WindowsAzure\MediaServices\Models\Asset;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class UtilitiesTest extends \PHPUnit_Framework_TestCase
+class UtilitiesTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Utilities::tryGetValue

--- a/tests/unit/WindowsAzure/Common/Internal/ValidateTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ValidateTest.php
@@ -30,6 +30,7 @@ use WindowsAzure\Common\Internal\InvalidArgumentTypeException;
 use WindowsAzure\Common\Internal\Resources;
 use WindowsAzure\Common\Internal\Utilities;
 use WindowsAzure\MediaServices\Models\Asset;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ValidateTest.
@@ -44,7 +45,7 @@ use WindowsAzure\MediaServices\Models\Asset;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ValidateTest extends \PHPUnit_Framework_TestCase
+class ValidateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Internal\Validate::isArray

--- a/tests/unit/WindowsAzure/Common/Models/GetServicePropertiesResultTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/GetServicePropertiesResultTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Models;
 use WindowsAzure\Common\Models\GetServicePropertiesResult;
 use WindowsAzure\Common\Models\ServiceProperties;
 use Tests\Framework\TestResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetServicePropertiesResult.
@@ -42,7 +43,7 @@ use Tests\Framework\TestResources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetServicePropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetServicePropertiesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\GetServicePropertiesResult::create

--- a/tests/unit/WindowsAzure/Common/Models/LoggingTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/LoggingTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\Common\Models\Logging;
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Models\RetentionPolicy;
 use WindowsAzure\Common\Internal\Utilities;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Logging.
@@ -43,7 +44,7 @@ use WindowsAzure\Common\Internal\Utilities;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class LoggingTest extends \PHPUnit_Framework_TestCase
+class LoggingTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\Logging::create

--- a/tests/unit/WindowsAzure/Common/Models/MetricsTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/MetricsTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\Common\Models\Metrics;
 use WindowsAzure\Common\Internal\Utilities;
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Models\RetentionPolicy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Metrics.
@@ -43,7 +44,7 @@ use WindowsAzure\Common\Models\RetentionPolicy;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class MetricsTest extends \PHPUnit_Framework_TestCase
+class MetricsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\Metrics::create

--- a/tests/unit/WindowsAzure/Common/Models/OAuthAccessTokenTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/OAuthAccessTokenTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Models;
 use WindowsAzure\Common\Models\OAuthAccessToken;
 use WindowsAzure\Common\Internal\Resources;
 use Tests\Framework\TestResources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class OAuthAccessToken.
@@ -42,7 +43,7 @@ use Tests\Framework\TestResources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class OAuthAccessTokenTest extends \PHPUnit_Framework_TestCase
+class OAuthAccessTokenTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\OAuthAccessToken::create

--- a/tests/unit/WindowsAzure/Common/Models/RetentionPolicyTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/RetentionPolicyTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\Common\Models;
 use WindowsAzure\Common\Models\RetentionPolicy;
 use Tests\Framework\TestResources;
 use WindowsAzure\Common\Internal\Utilities;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RetentionPolicy.
@@ -42,7 +43,7 @@ use WindowsAzure\Common\Internal\Utilities;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RetentionPolicyTest extends \PHPUnit_Framework_TestCase
+class RetentionPolicyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\RetentionPolicy::create

--- a/tests/unit/WindowsAzure/Common/Models/ServicePropertiesTest.php
+++ b/tests/unit/WindowsAzure/Common/Models/ServicePropertiesTest.php
@@ -32,6 +32,7 @@ use WindowsAzure\Common\Models\Metrics;
 use WindowsAzure\Common\Models\ServiceProperties;
 use WindowsAzure\Common\Models\GetServicePropertiesResult;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ServiceProperties.
@@ -46,7 +47,7 @@ use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServicePropertiesTest extends \PHPUnit_Framework_TestCase
+class ServicePropertiesTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\Models\ServiceProperties::create

--- a/tests/unit/WindowsAzure/Common/ServiceExceptionTest.php
+++ b/tests/unit/WindowsAzure/Common/ServiceExceptionTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\Common;
 
 use WindowsAzure\Common\ServiceException;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ServiceException.
@@ -40,7 +41,7 @@ use WindowsAzure\Common\ServiceException;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServiceExceptionTest extends \PHPUnit_Framework_TestCase
+class ServiceExceptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\Common\ServiceException::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Internal/ContentPropertiesSerializerTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Internal/ContentPropertiesSerializerTest.php
@@ -30,6 +30,7 @@ use WindowsAzure\MediaServices\Models\Asset;
 use WindowsAzure\MediaServices\Models\IngestManifest;
 use WindowsAzure\MediaServices\Models\Task;
 use WindowsAzure\MediaServices\Models\TaskOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ContentPropertiesSerializer.
@@ -44,7 +45,7 @@ use WindowsAzure\MediaServices\Models\TaskOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ContentPropertiesSerializerTest extends \PHPUnit_Framework_TestCase
+class ContentPropertiesSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Internal\ContentPropertiesSerializer::unserialize

--- a/tests/unit/WindowsAzure/MediaServices/Models/AccessPolicyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/AccessPolicyTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\AccessPolicy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -40,7 +41,7 @@ use WindowsAzure\MediaServices\Models\AccessPolicy;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AccessPolicyTest extends \PHPUnit_Framework_TestCase
+class AccessPolicyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\AccessPolicy::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/AssetDeliveryPolicyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/AssetDeliveryPolicyTest.php
@@ -28,6 +28,7 @@ use WindowsAzure\MediaServices\Models\AssetDeliveryPolicy;
 use WindowsAzure\MediaServices\Models\AssetDeliveryPolicyType;
 use WindowsAzure\MediaServices\Models\AssetDeliveryProtocol;
 use WindowsAzure\MediaServices\Models\AssetDeliveryPolicyConfigurationKey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for AssetDeliveryPolicy.
@@ -42,7 +43,7 @@ use WindowsAzure\MediaServices\Models\AssetDeliveryPolicyConfigurationKey;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AssetDeliveryPolicyTest extends \PHPUnit_Framework_TestCase
+class AssetDeliveryPolicyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\AssetDeliveryPolicy::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/AssetFileTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/AssetFileTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\AssetFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\AssetFile;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AssetFileTest extends \PHPUnit_Framework_TestCase
+class AssetFileTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\AssetFile::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/AssetTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/AssetTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\Asset;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\Asset;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AssetTest extends \PHPUnit_Framework_TestCase
+class AssetTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\Asset::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationOptionsTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationOptionsTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyOption;
 use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyRestriction;
 use WindowsAzure\MediaServices\Models\ContentKeyDeliveryType;
 use WindowsAzure\MediaServices\Models\ContentKeyRestrictionType;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ContentKeyAuthorizationPolicyOption.
@@ -43,7 +44,7 @@ use WindowsAzure\MediaServices\Models\ContentKeyRestrictionType;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ContentKeyAuthorizationOptionsTest extends \PHPUnit_Framework_TestCase
+class ContentKeyAuthorizationOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyOption::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationPolicyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationPolicyTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicy;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ContentKeyAuthorizationPolicy.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicy;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ContentKeyAuthorizationPolicyTest extends \PHPUnit_Framework_TestCase
+class ContentKeyAuthorizationPolicyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicy::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationRestrictionsTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyAuthorizationRestrictionsTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyRestriction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ContentKeyAuthorizationPolicyRestriction.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyRestriction;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ContentKeyAuthorizationRestrictionsTest extends \PHPUnit_Framework_TestCase
+class ContentKeyAuthorizationRestrictionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\ContentKeyAuthorizationPolicyRestriction::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/ContentKeyTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Models;
 use WindowsAzure\MediaServices\Models\ContentKey;
 use WindowsAzure\MediaServices\Models\ContentKeyTypes;
 use WindowsAzure\MediaServices\Models\ProtectionKeyTypes;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -41,7 +42,7 @@ use WindowsAzure\MediaServices\Models\ProtectionKeyTypes;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ContentKeyTest extends \PHPUnit_Framework_TestCase
+class ContentKeyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\ContentKey::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/EncodingReservedUnitTypeTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/EncodingReservedUnitTypeTest.php
@@ -26,6 +26,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\EncodingReservedUnitType;
 use WindowsAzure\MediaServices\Models\EncodingReservedUnit;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for EncodingReservedUnitType.
@@ -40,7 +41,7 @@ use WindowsAzure\MediaServices\Models\EncodingReservedUnit;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class EncodingReservedUnitTypeTest extends \PHPUnit_Framework_TestCase
+class EncodingReservedUnitTypeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\EncodingReservedUnit::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/ErrorDetailTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/ErrorDetailTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\ErrorDetail;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\ErrorDetail;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ErrorDetailTest extends \PHPUnit_Framework_TestCase
+class ErrorDetailTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\ErrorDetail::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestAssetTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestAssetTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\IngestManifestAsset;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\IngestManifestAsset;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class IngestManifestAssetTest extends \PHPUnit_Framework_TestCase
+class IngestManifestAssetTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\IngestManifestAsset::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestFileTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestFileTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\IngestManifestFile;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\IngestManifestFile;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class IngestManifestFileTest extends \PHPUnit_Framework_TestCase
+class IngestManifestFileTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\IngestManifestFile::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestStatisticsTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestStatisticsTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\IngestManifestStatistics;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\IngestManifestStatistics;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class IngestManifestStatisticsTest extends \PHPUnit_Framework_TestCase
+class IngestManifestStatisticsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\IngestManifestStatistics::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/IngestManifestTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\IngestManifest;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\IngestManifest;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class IngestManifestTest extends \PHPUnit_Framework_TestCase
+class IngestManifestTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\IngestManifest::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/JobTemplateTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/JobTemplateTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\JobTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\JobTemplate;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class JobTemplateTest extends \PHPUnit_Framework_TestCase
+class JobTemplateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\JobTemplate::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/JobTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/JobTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\Job;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\Job;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class JobTest extends \PHPUnit_Framework_TestCase
+class JobTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\Job::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/LocatorTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/LocatorTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\Locator;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\Locator;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class LocatorTest extends \PHPUnit_Framework_TestCase
+class LocatorTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\Locator::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/MediaProcessorTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/MediaProcessorTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\MediaProcessor;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\MediaProcessor;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class MediaProcessorTest extends \PHPUnit_Framework_TestCase
+class MediaProcessorTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\MediaProcessor::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/StorageAccountTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/StorageAccountTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\StorageAccount;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\StorageAccount;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class StorageAccountTest extends \PHPUnit_Framework_TestCase
+class StorageAccountTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\StorageAccount::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/TaskHistoricalEventTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/TaskHistoricalEventTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\TaskHistoricalEvent;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\TaskHistoricalEvent;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TaskHistoricalEventTest extends \PHPUnit_Framework_TestCase
+class TaskHistoricalEventTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\TaskHistoricalEvent::createFromOptions

--- a/tests/unit/WindowsAzure/MediaServices/Models/TaskTemplateTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/TaskTemplateTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\TaskTemplate;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\TaskTemplate;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TaskTemplateTest extends \PHPUnit_Framework_TestCase
+class TaskTemplateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\TaskTemplate::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Models/TaskTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Models/TaskTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Models;
 
 use WindowsAzure\MediaServices\Models\Task;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Represents access policy object used in media services.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Models\Task;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TaskTest extends \PHPUnit_Framework_TestCase
+class TaskTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Models\Task::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/AgcAndColorStripeRestrictionTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/AgcAndColorStripeRestrictionTest.php
@@ -26,6 +26,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\AgcAndColorStripeRestriction;
 use WindowsAzure\MediaServices\Templates\ErrorMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for AgcAndColorStripeRestriction.
@@ -40,7 +41,7 @@ use WindowsAzure\MediaServices\Templates\ErrorMessages;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AgcAndColorStripeRestrictionTest extends \PHPUnit_Framework_TestCase
+class AgcAndColorStripeRestrictionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\AgcAndColorStripeRestriction::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/ContentEncryptionKeyFromKeyIdentifierTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/ContentEncryptionKeyFromKeyIdentifierTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\ContentEncryptionKeyFromKeyIdentifier;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ContentEncryptionKeyFromKeyIdentifier.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\ContentEncryptionKeyFromKeyIdentifier;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ContentEncryptionKeyFromKeyIdentifierTest extends \PHPUnit_Framework_TestCase
+class ContentEncryptionKeyFromKeyIdentifierTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\ContentEncryptionKeyFromKeyIdentifier::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/ExplicitAnalogTelevisionRestrictionTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/ExplicitAnalogTelevisionRestrictionTest.php
@@ -26,6 +26,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\ExplicitAnalogTelevisionRestriction;
 use WindowsAzure\MediaServices\Templates\ErrorMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ExplicitAnalogTelevisionRestriction.
@@ -40,7 +41,7 @@ use WindowsAzure\MediaServices\Templates\ErrorMessages;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ExplicitAnalogTelevisionRestrictionTest extends \PHPUnit_Framework_TestCase
+class ExplicitAnalogTelevisionRestrictionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\ExplicitAnalogTelevisionRestriction::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/MediaServicesLicenseTemplateSerializerTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/MediaServicesLicenseTemplateSerializerTest.php
@@ -37,6 +37,7 @@ use WindowsAzure\MediaServices\Templates\ExplicitAnalogTelevisionRestriction;
 use WindowsAzure\MediaServices\Templates\PlayReadyLicenseType;
 use WindowsAzure\MediaServices\Templates\UnknownOutputPassingOption;
 use WindowsAzure\MediaServices\Templates\ErrorMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for MediaServicesLicenseTemplateSerializer.
@@ -51,7 +52,7 @@ use WindowsAzure\MediaServices\Templates\ErrorMessages;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class MediaServicesLicenseTemplateSerializerTest extends \PHPUnit_Framework_TestCase
+class MediaServicesLicenseTemplateSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\MediaServicesLicenseTemplateSerializer::deserialize

--- a/tests/unit/WindowsAzure/MediaServices/Templates/OpenIdConnectDiscoveryDocumentTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/OpenIdConnectDiscoveryDocumentTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\OpenIdConnectDiscoveryDocument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for OpenIdConnectDiscoveryDocument.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\OpenIdConnectDiscoveryDocument;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class OpenIdConnectDiscoveryDocumentTest extends \PHPUnit_Framework_TestCase
+class OpenIdConnectDiscoveryDocumentTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\OpenIdConnectDiscoveryDocument::getOpenIdDiscoveryUri

--- a/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyLicenseResponseTemplateTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyLicenseResponseTemplateTest.php
@@ -25,7 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\PlayReadyLicenseResponseTemplate;
-
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for PlayReadyLicenseTemplate.
@@ -40,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\PlayReadyLicenseResponseTemplate;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class PlayReadyLicenseResponseTemplateTest extends \PHPUnit_Framework_TestCase
+class PlayReadyLicenseResponseTemplateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\PlayReadyLicenseResponseTemplate::getLicenseTemplates

--- a/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyLicenseTemplateTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyLicenseTemplateTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 use WindowsAzure\MediaServices\Templates\PlayReadyLicenseTemplate;
 use WindowsAzure\MediaServices\Templates\PlayReadyPlayRight;
 use WindowsAzure\MediaServices\Templates\ContentEncryptionKeyFromKeyIdentifier;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for PlayReadyLicenseTemplate.
@@ -41,7 +42,7 @@ use WindowsAzure\MediaServices\Templates\ContentEncryptionKeyFromKeyIdentifier;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class PlayReadyLicenseTemplateTest extends \PHPUnit_Framework_TestCase
+class PlayReadyLicenseTemplateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\PlayReadyLicenseTemplate::getAllowTestDevices

--- a/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyPlayRightTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/PlayReadyPlayRightTest.php
@@ -30,6 +30,7 @@ use WindowsAzure\MediaServices\Templates\AgcAndColorStripeRestriction;
 use WindowsAzure\MediaServices\Templates\ExplicitAnalogTelevisionRestriction;
 use WindowsAzure\MediaServices\Templates\UnknownOutputPassingOption;
 use WindowsAzure\MediaServices\Templates\ErrorMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for PlayReadyPlayRight.
@@ -44,7 +45,7 @@ use WindowsAzure\MediaServices\Templates\ErrorMessages;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class PlayReadyPlayRightTest extends \PHPUnit_Framework_TestCase
+class PlayReadyPlayRightTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\PlayReadyPlayRight::getFirstPlayExpiration

--- a/tests/unit/WindowsAzure/MediaServices/Templates/ScmsRestrictionTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/ScmsRestrictionTest.php
@@ -26,6 +26,7 @@ namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\ScmsRestriction;
 use WindowsAzure\MediaServices\Templates\ErrorMessages;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for ScmsRestriction.
@@ -40,7 +41,7 @@ use WindowsAzure\MediaServices\Templates\ErrorMessages;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ScmsRestrictionTest extends \PHPUnit_Framework_TestCase
+class ScmsRestrictionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\ScmsRestriction::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/SymmetricVerificationKeyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/SymmetricVerificationKeyTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\SymmetricVerificationKey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for SymmetricVerificationKey.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\SymmetricVerificationKey;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class SymmetricVerificationKeyTest extends \PHPUnit_Framework_TestCase
+class SymmetricVerificationKeyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\SymmetricVerificationKey::getKeyValue

--- a/tests/unit/WindowsAzure/MediaServices/Templates/TokenClaimsTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/TokenClaimsTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\TokenClaim;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for TokenClaim.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\TokenClaim;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TokenClaimsTest extends \PHPUnit_Framework_TestCase
+class TokenClaimsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\TokenClaim::__construct

--- a/tests/unit/WindowsAzure/MediaServices/Templates/TokenRestrictionTemplateSerializerTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/TokenRestrictionTemplateSerializerTest.php
@@ -32,6 +32,7 @@ use WindowsAzure\MediaServices\Templates\TokenClaim;
 use WindowsAzure\MediaServices\Templates\SymmetricVerificationKey;
 use WindowsAzure\MediaServices\Templates\TokenVerificationKey;
 use WindowsAzure\MediaServices\Templates\X509CertTokenVerificationKey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for TokenRestrictionTemplateSerializer.
@@ -46,7 +47,7 @@ use WindowsAzure\MediaServices\Templates\X509CertTokenVerificationKey;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TokenRestrictionTemplateSerializerTest extends \PHPUnit_Framework_TestCase
+class TokenRestrictionTemplateSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\TokenRestrictionTemplateSerializer::deserialize

--- a/tests/unit/WindowsAzure/MediaServices/Templates/TokenRestrictionTemplateTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/TokenRestrictionTemplateTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\MediaServices\Templates\SymmetricVerificationKey;
 use WindowsAzure\MediaServices\Templates\TokenClaim;
 use WindowsAzure\MediaServices\Templates\TokenType;
 use WindowsAzure\MediaServices\Templates\OpenIdConnectDiscoveryDocument;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for TokenRestrictionTemplate.
@@ -43,7 +44,7 @@ use WindowsAzure\MediaServices\Templates\OpenIdConnectDiscoveryDocument;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class TokenRestrictionTemplateTest extends \PHPUnit_Framework_TestCase
+class TokenRestrictionTemplateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\TokenRestrictionTemplate::getAlternateVerificationKeys

--- a/tests/unit/WindowsAzure/MediaServices/Templates/WidevineMessageTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/WidevineMessageTest.php
@@ -30,6 +30,7 @@ use WindowsAzure\MediaServices\Templates\AllowedTrackTypes;
 use WindowsAzure\MediaServices\Templates\ContentKeySpecs;
 use WindowsAzure\MediaServices\Templates\Hdcp;
 use WindowsAzure\MediaServices\Templates\RequiredOutputProtection;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for WidevineMessage.
@@ -44,7 +45,7 @@ use WindowsAzure\MediaServices\Templates\RequiredOutputProtection;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class WidevineMessageTest extends \PHPUnit_Framework_TestCase
+class WidevineMessageTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\WidevineMessageSerializer::serialize

--- a/tests/unit/WindowsAzure/MediaServices/Templates/X509CertTokenVerificationKeyTest.php
+++ b/tests/unit/WindowsAzure/MediaServices/Templates/X509CertTokenVerificationKeyTest.php
@@ -25,6 +25,7 @@
 namespace Tests\unit\WindowsAzure\MediaServices\Templates;
 
 use WindowsAzure\MediaServices\Templates\X509CertTokenVerificationKey;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit Tests for X509CertTokenVerificationKey.
@@ -39,7 +40,7 @@ use WindowsAzure\MediaServices\Templates\X509CertTokenVerificationKey;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class X509CertTokenVerificationKeyTest extends \PHPUnit_Framework_TestCase
+class X509CertTokenVerificationKeyTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\MediaServices\Templates\X509CertTokenVerificationKey::getRawBody

--- a/tests/unit/WindowsAzure/ServiceBus/Internal/ActionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/Internal/ActionTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\Internal;
 
 use WindowsAzure\ServiceBus\Internal\Action;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Action.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Internal\Action;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ActionTest extends \PHPUnit_Framework_TestCase
+class ActionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Internal\Action::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/Internal/ActiveTokenTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/Internal/ActiveTokenTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -27,6 +27,7 @@ namespace Tests\Unit\WindowsAzure\ServiceBus\Models;
 
 use WindowsAzure\ServiceBus\Internal\ActiveToken;
 use WindowsAzure\ServiceBus\Internal\WrapAccessTokenResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ActiveToken.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Internal\WrapAccessTokenResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ActiveTokenTest extends \PHPUnit_Framework_TestCase
+class ActiveTokenTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Internal\ActiveToken::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/Internal/FilterTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/Internal/FilterTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -26,6 +26,7 @@
 namespace Tests\Unit\WindowsAzure\ServiceBus\Models;
 
 use WindowsAzure\ServiceBus\Internal\Filter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Filter.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Internal\Filter;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class FilterTest extends \PHPUnit_Framework_TestCase
+class FilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Internal\Filter::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/BrokerPropertiesTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/BrokerPropertiesTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * LICENSE: Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +10,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -22,11 +21,11 @@
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\BrokerProperties;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class BrokerProperties.
@@ -41,8 +40,9 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
+class BrokerPropertiesTest extends TestCase
 {
+
     /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::__construct
      */
@@ -68,18 +68,15 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertEquals(
-            1,
-            $brokerProperties->getMessageId()
+                1, $brokerProperties->getMessageId()
         );
 
         $this->assertEquals(
-            'label1',
-            $brokerProperties->getLabel()
+                'label1', $brokerProperties->getLabel()
         );
 
         $this->assertEquals(
-            '1@1.com',
-            $brokerProperties->getReplyTo()
+                '1@1.com', $brokerProperties->getReplyTo()
         );
     }
 
@@ -94,7 +91,7 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $expectedSessionId = 'testSessionId';
         $expectedDeliveryCount = 38;
         $expectedLockedUntilUtc = \DateTime::createFromFormat(
-            Resources::AZURE_DATE_FORMAT, 'Sun, 06 Nov 2011 01:00:00 GMT'
+                        Resources::AZURE_DATE_FORMAT, 'Sun, 06 Nov 2011 01:00:00 GMT'
         );
         $expectedLockToken = 'testLockToken';
         $expectedMessageId = 'testMessageId';
@@ -113,78 +110,63 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertEquals(
-            $expectedCorrelationId,
-            $brokerProperties->getCorrelationId()
+                $expectedCorrelationId, $brokerProperties->getCorrelationId()
         );
 
         $this->assertEquals(
-            $expectedSessionId,
-            $brokerProperties->getSessionId()
+                $expectedSessionId, $brokerProperties->getSessionId()
         );
 
         $this->assertEquals(
-            $expectedDeliveryCount,
-            $brokerProperties->getDeliveryCount()
+                $expectedDeliveryCount, $brokerProperties->getDeliveryCount()
         );
 
         $this->assertEquals(
-            $expectedLockedUntilUtc->format(Resources::AZURE_DATE_FORMAT),
-            $brokerProperties->getLockedUntilUtc()->format(Resources::AZURE_DATE_FORMAT)
+                $expectedLockedUntilUtc->format(Resources::AZURE_DATE_FORMAT), $brokerProperties->getLockedUntilUtc()->format(Resources::AZURE_DATE_FORMAT)
         );
 
         $this->assertEquals(
-            $expectedLockToken,
-            $brokerProperties->getLockToken()
+                $expectedLockToken, $brokerProperties->getLockToken()
         );
 
         $this->assertEquals(
-            $expectedMessageId,
-            $brokerProperties->getMessageId()
+                $expectedMessageId, $brokerProperties->getMessageId()
         );
 
         $this->assertEquals(
-            $expectedLabel,
-            $brokerProperties->getLabel()
+                $expectedLabel, $brokerProperties->getLabel()
         );
 
         $this->assertEquals(
-            $expectedReplyTo,
-            $brokerProperties->getReplyTo()
+                $expectedReplyTo, $brokerProperties->getReplyTo()
         );
 
         $this->assertEquals(
-            $expectedSequenceNumber,
-            $brokerProperties->getSequenceNumber()
+                $expectedSequenceNumber, $brokerProperties->getSequenceNumber()
         );
 
         $this->assertEquals(
-            $expectedTimeToLive,
-            $brokerProperties->getTimeToLive()
+                $expectedTimeToLive, $brokerProperties->getTimeToLive()
         );
 
         $this->assertEquals(
-            $expectedTo,
-            $brokerProperties->getTo()
+                $expectedTo, $brokerProperties->getTo()
         );
 
         $this->assertEquals(
-            $expectedScheduledEnqueueTimeUtc,
-            $brokerProperties->getScheduledEnqueueTimeUtc()
+                $expectedScheduledEnqueueTimeUtc, $brokerProperties->getScheduledEnqueueTimeUtc()
         );
 
         $this->assertEquals(
-            $expectedReplyToSessionId,
-            $brokerProperties->getReplyToSessionId()
+                $expectedReplyToSessionId, $brokerProperties->getReplyToSessionId()
         );
 
         $this->assertEquals(
-            $expectedMessageLocation,
-            $brokerProperties->getMessageLocation()
+                $expectedMessageLocation, $brokerProperties->getMessageLocation()
         );
 
         $this->assertEquals(
-            $expectedLockLocation,
-            $brokerProperties->getLockLocation()
+                $expectedLockLocation, $brokerProperties->getLockLocation()
         );
     }
 
@@ -204,8 +186,7 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertEquals(
-            $expected,
-            $brokerProperties->toString()
+                $expected, $brokerProperties->toString()
         );
     }
 
@@ -217,7 +198,7 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         // Setup
         $expected = '{"CorrelationId":"testCorrelationId","SessionId":"testSessionId","DeliveryCount":38,"LockedUntilUtc":"Sun, 06 Nov 2011 01:00:00 GMT","LockToken":"testLockToken","MessageId":"testMessageId","Label":"testLabel","ReplyTo":"testReplyTo","SequenceNumber":88,"TimeToLive":123.456,"To":"testTo","ScheduledEnqueueTimeUtc":"Sun, 06 Nov 2011 01:00:00 GMT","ReplyToSessionId":"testReplyToSessionId","MessageLocation":"testMessageLocation","LockLocation":"testLockLocation"}';
         $lockedUntilUtc = \DateTime::createFromFormat(
-            'Y-m-d H:i:s', '2011-11-06 01:00:00', new \DateTimeZone('UTC'));
+                        'Y-m-d H:i:s', '2011-11-06 01:00:00', new \DateTimeZone('UTC'));
         $timeToLive = '123.456';
         $scheduledEnqueueTimeUtc = $lockedUntilUtc;
 
@@ -241,12 +222,11 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertEquals(
-            $expected,
-            $brokerProperties->toString()
+                $expected, $brokerProperties->toString()
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getCorrelationId
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setCorrelationId
      */
@@ -260,14 +240,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setCorrelationId($expected);
         $actual = $brokerProperties->getCorrelationId();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getSessionId
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setSessionId
      */
@@ -281,14 +260,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setSessionId($expected);
         $actual = $brokerProperties->getSessionId();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getDeliveryCount
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setDeliveryCount
      */
@@ -302,14 +280,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setDeliveryCount($expected);
         $actual = $brokerProperties->getDeliveryCount();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getLockedUntilUtc
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setLockedUntilUtc
      */
@@ -325,12 +302,11 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
 
         // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getLockToken
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setLockToken
      */
@@ -344,14 +320,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setLockToken($expected);
         $actual = $brokerProperties->getLockToken();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getMessageId
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setMessageId
      */
@@ -365,14 +340,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setMessageId($expected);
         $actual = $brokerProperties->getMessageId();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getLabel
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setLabel
      */
@@ -386,14 +360,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setLabel($expected);
         $actual = $brokerProperties->getLabel();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getReplyTo
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setReplyTo
      */
@@ -407,14 +380,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setReplyTo($expected);
         $actual = $brokerProperties->getReplyTo();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getSequenceNumber
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setSequenceNumber
      */
@@ -428,14 +400,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setSequenceNumber($expected);
         $actual = $brokerProperties->getSequenceNumber();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getTimeToLive
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setTimeToLive
      */
@@ -449,14 +420,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setTimeToLive($expected);
         $actual = $brokerProperties->getTimeToLive();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getTo
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setTo
      */
@@ -470,14 +440,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setTo($expected);
         $actual = $brokerProperties->getTo();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getScheduledEnqueueTimeUtc
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setScheduledEnqueueTimeUtc
      */
@@ -491,14 +460,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setScheduledEnqueueTimeUtc($expected);
         $actual = $brokerProperties->getScheduledEnqueueTimeUtc();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getReplyToSessionId
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setReplyToSessionId
      */
@@ -512,14 +480,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setReplyToSessionId($expected);
         $actual = $brokerProperties->getReplyToSessionId();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getMessageLocation
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setMessageLocation
      */
@@ -533,14 +500,13 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setMessageLocation($expected);
         $actual = $brokerProperties->getMessageLocation();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
 
-    /** 
+    /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::getLockLocation
      * @covers \WindowsAzure\ServiceBus\Models\BrokerProperties::setLockLocation
      */
@@ -554,10 +520,10 @@ class BrokerPropertiesTest extends \PHPUnit_Framework_TestCase
         $brokerProperties->setLockLocation($expected);
         $actual = $brokerProperties->getLockLocation();
 
-        // Assert 
+        // Assert
         $this->assertEquals(
-            $expected,
-            $actual
+                $expected, $actual
         );
     }
+
 }

--- a/tests/unit/WindowsAzure/ServiceBus/models/BrokeredMessageTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/BrokeredMessageTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\BrokeredMessage;
 use WindowsAzure\ServiceBus\Models\BrokerProperties;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class brokered message. 
@@ -42,7 +43,7 @@ use WindowsAzure\ServiceBus\Models\BrokerProperties;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class BrokeredMessageTest extends \PHPUnit_Framework_TestCase
+class BrokeredMessageTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\BrokeredMessage::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/CorrelationFilterTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/CorrelationFilterTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\CorrelationFilter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CorrelationFilter.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\CorrelationFilter;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class CorrelationFilterTest extends \PHPUnit_Framework_TestCase
+class CorrelationFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\CorrelationFilter::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/EmptyRuleActionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/EmptyRuleActionTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\EmptyRuleAction;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class EmptyRuleAction.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\EmptyRuleAction;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class EmptyRuleActionTest extends \PHPUnit_Framework_TestCase
+class EmptyRuleActionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\EmptyRuleAction::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/FalseFilterTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/FalseFilterTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\FalseFilter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class FalseFilter.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\FalseFilter;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class FalseFilterTest extends \PHPUnit_Framework_TestCase
+class FalseFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\FalseFilter::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListOptionsTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListOptions;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListOptionsTest extends \PHPUnit_Framework_TestCase
+class ListOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListQueuesOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListQueuesOptionsTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListQueuesOptions;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListQueuesOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListQueuesOptionsTest extends \PHPUnit_Framework_TestCase
+class ListQueuesOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListQueuesOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListQueuesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListQueuesResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListQueuesResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\ListQueuesResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListQueuesResultTest extends \PHPUnit_Framework_TestCase
+class ListQueuesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListQueuesResult::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListRulesOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListRulesOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListRulesOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\ListRulesOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListRulesOptionsTest extends \PHPUnit_Framework_TestCase
+class ListRulesOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListRulesOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListRulesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListRulesResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListRulesResult;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListRulesResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListRulesResultTest extends \PHPUnit_Framework_TestCase
+class ListRulesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListRulesResult::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListSubscriptionsOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListSubscriptionsOptionsTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListSubscriptionsOptions;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListSubscriptionsOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListSubscriptionsOptionsTest extends \PHPUnit_Framework_TestCase
+class ListSubscriptionsOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListSubscriptionsOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListSubscriptionsResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListSubscriptionsResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListSubscriptionsResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\ListSubscriptionsResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListSubscriptionsResultTest extends \PHPUnit_Framework_TestCase
+class ListSubscriptionsResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListSubscriptionsResult::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListTopicsOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListTopicsOptionsTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListTopicsOptions;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListTopicsOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListTopicsOptionsTest extends \PHPUnit_Framework_TestCase
+class ListTopicsOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListTopicsOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ListTopicsResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ListTopicsResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ListTopicsResult;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\ListTopicsResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ListTopicsResultTest extends \PHPUnit_Framework_TestCase
+class ListTopicsResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ListTopicsResult::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/QueueDescriptionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/QueueDescriptionTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\QueueDescription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\QueueDescription;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class QueueDescriptionTest extends \PHPUnit_Framework_TestCase
+class QueueDescriptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\QueueDescription::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/QueueInfoTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/QueueInfoTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 use WindowsAzure\ServiceBus\Models\QueueDescription;
 use WindowsAzure\ServiceBus\Models\QueueInfo;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -42,7 +43,7 @@ use WindowsAzure\ServiceBus\Models\QueueInfo;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class QueueInfoTest extends \PHPUnit_Framework_TestCase
+class QueueInfoTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\QueueInfo::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/ReceiveMessageOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ReceiveMessageOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\ReceiveMessageOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\ReceiveMessageOptions;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class ReceiveMessageOptionsTest extends \PHPUnit_Framework_TestCase
+class ReceiveMessageOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\ReceiveMessageOptions::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/RuleDescriptionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/RuleDescriptionTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\ServiceBus\Internal\Action;
 use WindowsAzure\ServiceBus\Internal\Filter;
 use WindowsAzure\ServiceBus\Models\RuleDescription;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -43,7 +44,7 @@ use WindowsAzure\ServiceBus\Models\RuleDescription;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class RuleDescriptionTest extends \PHPUnit_Framework_TestCase
+class RuleDescriptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\RuleDescription::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/RuleInfoTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/RuleInfoTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\ServiceBus\Internal\Action;
 use WindowsAzure\ServiceBus\Internal\Filter;
 use WindowsAzure\ServiceBus\Models\RuleDescription;
 use WindowsAzure\ServiceBus\Models\RuleInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -43,7 +44,7 @@ use WindowsAzure\ServiceBus\Models\RuleInfo;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class RuleInfoTest extends \PHPUnit_Framework_TestCase
+class RuleInfoTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\RuleInfo::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/SqlFilterTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/SqlFilterTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\SqlFilter;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\SqlFilter;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class SqlFilterTest extends \PHPUnit_Framework_TestCase
+class SqlFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\SqlFilter::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/SqlRuleActionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/SqlRuleActionTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\SqlRuleAction;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\SqlRuleAction;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class SqlRuleActionTest extends \PHPUnit_Framework_TestCase
+class SqlRuleActionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\SqlRuleAction::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/SubscriptionDescriptionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/SubscriptionDescriptionTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\SubscriptionDescription;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\SubscriptionDescription;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class SubscriptionDescriptionTest extends \PHPUnit_Framework_TestCase
+class SubscriptionDescriptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\SubscriptionDescription::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/SubscriptionInfoTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/SubscriptionInfoTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\SubscriptionDescription;
 use WindowsAzure\ServiceBus\Models\SubscriptionInfo;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\SubscriptionInfo;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class SubscriptionInfoTest extends \PHPUnit_Framework_TestCase
+class SubscriptionInfoTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\SubscriptionInfo::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/TopicDescriptionTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/TopicDescriptionTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\TopicDescription;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceBus\Models\TopicDescription;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class TopicDescriptionTest extends \PHPUnit_Framework_TestCase
+class TopicDescriptionTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\TopicDescription::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/TopicInfoTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/TopicInfoTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\ServiceBus\models;
 use WindowsAzure\ServiceBus\Models\TopicDescription;
 use WindowsAzure\ServiceBus\Models\TopicInfo;
 
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -42,7 +43,7 @@ use WindowsAzure\ServiceBus\Models\TopicInfo;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class TopicInfoTest extends \PHPUnit_Framework_TestCase
+class TopicInfoTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\TopicInfo::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/TrueFilterTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/TrueFilterTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Models\TrueFilter;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class TrueFilter.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Models\TrueFilter;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class TrueFilterTest extends \PHPUnit_Framework_TestCase
+class TrueFilterTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Models\TrueFilter::__construct

--- a/tests/unit/WindowsAzure/ServiceBus/models/WrapAccessTokenResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/WrapAccessTokenResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceBus\models;
 
 use WindowsAzure\ServiceBus\Internal\WrapAccessTokenResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WrapAccessTokenResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceBus\Internal\WrapAccessTokenResult;
  *
  * @link      https://github.com/WindowsAzure/azure-sdk-for-php
  */
-class WrapAccessTokenResultTest extends \PHPUnit_Framework_TestCase
+class WrapAccessTokenResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceBus\Internal\WrapAccessTokenResult::create

--- a/tests/unit/WindowsAzure/ServiceManagement/Internal/ServiceTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Internal/ServiceTest.php
@@ -29,6 +29,7 @@ use WindowsAzure\Common\Internal\Serialization\JsonSerializer;
 use WindowsAzure\ServiceManagement\Internal\Service;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Service.
@@ -43,7 +44,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ServiceTest extends \PHPUnit_Framework_TestCase
+class ServiceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Internal\Service::setName

--- a/tests/unit/WindowsAzure/ServiceManagement/Internal/WindowsAzureServiceTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Internal/WindowsAzureServiceTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Internal;
 
 use WindowsAzure\ServiceManagement\Internal\WindowsAzureService;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class WindowsAzureService.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Internal\WindowsAzureService;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class WindowsAzureServiceTest extends \PHPUnit_Framework_TestCase
+class WindowsAzureServiceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Internal\WindowsAzureService::setAffinityGroup

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/AffinityGroupTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/AffinityGroupTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\AffinityGroup;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class AffinityGroup.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AffinityGroupTest extends \PHPUnit_Framework_TestCase
+class AffinityGroupTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\AffinityGroup::toArray

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/AsynchronousOperationResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/AsynchronousOperationResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\AsynchronousOperationResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class AsynchronousOperationResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\AsynchronousOperationResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AsynchronousOperationResultTest extends \PHPUnit_Framework_TestCase
+class AsynchronousOperationResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\AsynchronousOperationResult::create

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ChangeDeploymentConfigurationOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ChangeDeploymentConfigurationOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\ChangeDeploymentConfigurationOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ChangeDeploymentConfigurationOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\ChangeDeploymentConfigurationOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ChangeDeploymentConfigurationOptionsTest extends \PHPUnit_Framework_TestCase
+class ChangeDeploymentConfigurationOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\ChangeDeploymentConfigurationOptions::setTreatWarningsAsErrors

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/CreateAffinityGroupOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/CreateAffinityGroupOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\CreateAffinityGroupOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CreateAffinityGroupOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\CreateAffinityGroupOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class CreateAffinityGroupOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateAffinityGroupOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\CreateAffinityGroupOptions::setDescription

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/CreateDeploymentOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/CreateDeploymentOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\CreateDeploymentOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CreateDeploymentOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\CreateDeploymentOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class CreateDeploymentOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateDeploymentOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\CreateDeploymentOptions::setStartDeployment

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/CreateStorageServiceOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/CreateStorageServiceOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\Unit\WindowsAzure\CreateServiceOptionsManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\CreateServiceOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CreateServiceOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\CreateServiceOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class CreateStorageServiceOptionsTest extends \PHPUnit_Framework_TestCase
+class CreateStorageServiceOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\CreateServiceOptions::setDescription

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentSlotTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentSlotTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\DeploymentSlot;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class DeploymentSlot.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\DeploymentSlot;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class DeploymentSlotTest extends \PHPUnit_Framework_TestCase
+class DeploymentSlotTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\DeploymentSlot::isValid

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentStatusTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentStatusTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\DeploymentStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class DeploymentStatus.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\DeploymentStatus;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class DeploymentStatusTest extends \PHPUnit_Framework_TestCase
+class DeploymentStatusTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\DeploymentStatus::isValid

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/DeploymentTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 use WindowsAzure\ServiceManagement\Models\Deployment;
 use WindowsAzure\ServiceManagement\Models\DeploymentSlot;
 use WindowsAzure\ServiceManagement\Models\UpgradeStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Deployment.
@@ -42,7 +43,7 @@ use WindowsAzure\ServiceManagement\Models\UpgradeStatus;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class DeploymentTest extends \PHPUnit_Framework_TestCase
+class DeploymentTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\Deployment::setName

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetAffinityGroupPropertiesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetAffinityGroupPropertiesResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetAffinityGroupPropertiesResult;
 use WindowsAzure\ServiceManagement\Models\AffinityGroup;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetAffinityGroupPropertiesResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceManagement\Models\AffinityGroup;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetAffinityGroupPropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetAffinityGroupPropertiesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetAffinityGroupPropertiesResult::create

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetDeploymentOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetDeploymentOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetDeploymentOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetDeploymentOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\GetDeploymentOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetDeploymentOptionsTest extends \PHPUnit_Framework_TestCase
+class GetDeploymentOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetDeploymentOptions::setSlot

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetDeploymentResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetDeploymentResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetDeploymentResult;
 use WindowsAzure\ServiceManagement\Models\Deployment;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetDeploymentResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceManagement\Models\Deployment;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetDeploymentResultTest extends \PHPUnit_Framework_TestCase
+class GetDeploymentResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetDeploymentResult::setDeployment

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetHostedServicePropertiesOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetHostedServicePropertiesOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetHostedServicePropertiesOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetHostedServicePropertiesOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\GetHostedServicePropertiesOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetHostedServicePropertiesOptionsTest extends \PHPUnit_Framework_TestCase
+class GetHostedServicePropertiesOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetHostedServicePropertiesOptions::setEmbedDetail

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetHostedServicePropertiesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetHostedServicePropertiesResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetHostedServicePropertiesResult;
 use WindowsAzure\ServiceManagement\Models\HostedService;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetHostedServicePropertiesResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceManagement\Models\HostedService;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetHostedServicePropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetHostedServicePropertiesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetHostedServicePropertiesResult::getHostedService 

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetOperationStatusResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetOperationStatusResultTest.php
@@ -28,6 +28,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 use WindowsAzure\ServiceManagement\Models\GetOperationStatusResult;
 use WindowsAzure\Common\ServiceException;
 use WindowsAzure\ServiceManagement\Models\OperationStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetOperationStatusResult.
@@ -42,7 +43,7 @@ use WindowsAzure\ServiceManagement\Models\OperationStatus;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetOperationStatusResultTest extends \PHPUnit_Framework_TestCase
+class GetOperationStatusResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetOperationStatusResult::create

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetStorageServiceKeysResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetStorageServiceKeysResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetStorageServiceKeysResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetStorageServiceKeysResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\GetStorageServiceKeysResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetStorageServiceKeysResultTest extends \PHPUnit_Framework_TestCase
+class GetStorageServiceKeysResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetStorageServiceKeysResult::setUrl

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/GetStorageServicePropertiesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/GetStorageServicePropertiesResultTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\GetStorageServicePropertiesResult;
 use WindowsAzure\ServiceManagement\Models\StorageService;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class GetStorageServicePropertiesResult.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceManagement\Models\StorageService;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GetStorageServicePropertiesResultTest extends \PHPUnit_Framework_TestCase
+class GetStorageServicePropertiesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\GetStorageServicePropertiesResult::setStorageService

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/HostedServiceTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/HostedServiceTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\HostedService;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class HostedService.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\HostedService;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class HostedServiceTest extends \PHPUnit_Framework_TestCase
+class HostedServiceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\HostedService::setDeployments

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/InputEndpointTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/InputEndpointTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\InputEndpoint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class InputEndpoint.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\InputEndpoint;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class InputEndpointTest extends \PHPUnit_Framework_TestCase
+class InputEndpointTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\InputEndpoint::setRoleName

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ListAffinityGroupsResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ListAffinityGroupsResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\ListAffinityGroupsResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ListAffinityGroupsResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\ListAffinityGroupsResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ListAffinityGroupsResultTest extends \PHPUnit_Framework_TestCase
+class ListAffinityGroupsResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\ListAffinityGroupsResult::setAffinityGroups

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ListHostedServicesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ListHostedServicesResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\ListHostedServicesResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ListHostedServicesResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\ListHostedServicesResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ListHostedServicesResultTest extends \PHPUnit_Framework_TestCase
+class ListHostedServicesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\ListHostedServicesResult::setHostedServices

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ListLocationsResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ListLocationsResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\ListLocationsResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ListLocationsResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\ListLocationsResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ListLocationsResultTest extends \PHPUnit_Framework_TestCase
+class ListLocationsResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\ListLocationsResult::setLocations

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ListStorageServicesResultTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ListStorageServicesResultTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\ListStorageServicesResult;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ListStorageServicesResult.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\ListStorageServicesResult;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ListStorageServicesResultTest extends \PHPUnit_Framework_TestCase
+class ListStorageServicesResultTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\ListStorageServicesResult::setStorageServices

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/LocationTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/LocationTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\Location;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Location.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\Location;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class LocationTest extends \PHPUnit_Framework_TestCase
+class LocationTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\Location::setName

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/ModeTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/ModeTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\Mode;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Mode.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\Mode;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ModeTest extends \PHPUnit_Framework_TestCase
+class ModeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\Mode::isValid

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/RoleInstanceTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/RoleInstanceTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\RoleInstance;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleInstance.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\RoleInstance;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleInstanceTest extends \PHPUnit_Framework_TestCase
+class RoleInstanceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\RoleInstance::setRoleName

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/RoleTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/RoleTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\Role;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Role.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\Role;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleTest extends \PHPUnit_Framework_TestCase
+class RoleTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\Role::setRoleName

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/StorageServiceTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/StorageServiceTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\StorageService;
 use WindowsAzure\Common\Internal\Resources;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class StorageService.
@@ -41,7 +42,7 @@ use WindowsAzure\Common\Internal\Resources;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class StorageServiceTest extends \PHPUnit_Framework_TestCase
+class StorageServiceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\StorageService::__construct

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/UpdateServiceOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/UpdateServiceOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\UpdateServiceOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class UpdateServiceOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\UpdateServiceOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class UpdateServiceOptionsTest extends \PHPUnit_Framework_TestCase
+class UpdateServiceOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\UpdateServiceOptions::setDescription

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/UpgradeDeploymentOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/UpgradeDeploymentOptionsTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\UpgradeDeploymentOptions;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class UpgradeDeploymentOptions.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\UpgradeDeploymentOptions;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class UpgradeDeploymentOptionsTest extends \PHPUnit_Framework_TestCase
+class UpgradeDeploymentOptionsTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\UpgradeDeploymentOptions::setRoleToUpgrade

--- a/tests/unit/WindowsAzure/ServiceManagement/Models/UpgradeStatusTest.php
+++ b/tests/unit/WindowsAzure/ServiceManagement/Models/UpgradeStatusTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceManagement\Models;
 
 use WindowsAzure\ServiceManagement\Models\UpgradeStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class UpgradeStatus.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceManagement\Models\UpgradeStatus;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class UpgradeStatusTest extends \PHPUnit_Framework_TestCase
+class UpgradeStatusTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceManagement\Models\UpgradeStatus::setUpgradeType

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/AcquireCurrentStateTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/AcquireCurrentStateTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\AcquireCurrentState;
 use WindowsAzure\ServiceRuntime\Internal\CurrentStatus;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class AcquireCurrentState.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\CurrentStatus;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class AcquireCurrentStateTest extends \PHPUnit_Framework_TestCase
+class AcquireCurrentStateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\AcquireCurrentState::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/ChunkedGoalStateDeserializerTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/ChunkedGoalStateDeserializerTest.php
@@ -30,6 +30,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\ChunkedGoalStateDeserializer;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ChunkedGoalStateDeserializer.
@@ -44,7 +45,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ChunkedGoalStateDeserializerTest extends \PHPUnit_Framework_TestCase
+class ChunkedGoalStateDeserializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\ChunkedGoalStateDeserializer::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/CurrentStateTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/CurrentStateTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\CurrentState;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CurrentState.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\CurrentState;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class CurrentStateTest extends \PHPUnit_Framework_TestCase
+class CurrentStateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\CurrentState::getClientId

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/FileInputChannelTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/FileInputChannelTest.php
@@ -30,6 +30,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\ChannelNotAvailableException;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class FileInputChannel.
@@ -44,7 +45,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class FileInputChannelTest extends \PHPUnit_Framework_TestCase
+class FileInputChannelTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\FileInputChannel::getInputStream

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/FileOutputChannelTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/FileOutputChannelTest.php
@@ -30,6 +30,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\FileOutputChannel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class FileOutputChannel.
@@ -44,7 +45,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileOutputChannel;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class FileOutputChannelTest extends \PHPUnit_Framework_TestCase
+class FileOutputChannelTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\FileOutputChannel::getOutputStream

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/GoalStateTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/GoalStateTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\Common\Internal\Utilities;
 use WindowsAzure\ServiceRuntime\Internal\GoalState;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class CurrentState.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\GoalState;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class GoalStateTest extends \PHPUnit_Framework_TestCase
+class GoalStateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\GoalState::getDeadline

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/LocalResourceTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/LocalResourceTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\LocalResource;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class LocalResource.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\LocalResource;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class LocalResourceTest extends \PHPUnit_Framework_TestCase
+class LocalResourceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\LocalResource::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeClientFactoryTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeClientFactoryTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeClientFactory;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Protocol1RuntimeClientFactory.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeClientFactory;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class Protocol1RuntimeClientFactoryTest extends \PHPUnit_Framework_TestCase
+class Protocol1RuntimeClientFactoryTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeClientFactory::getVersion

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeClientTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeClientTest.php
@@ -38,6 +38,7 @@ use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient;
 use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeGoalStateClient;
 use WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer;
 use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Protocol1RuntimeClient.
@@ -52,7 +53,7 @@ use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class Protocol1RuntimeClientTest extends \PHPUnit_Framework_TestCase
+class Protocol1RuntimeClientTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeClient::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeCurrentStateClientTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeCurrentStateClientTest.php
@@ -1,5 +1,4 @@
 <?php
-
 /**
  * LICENSE: Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -11,7 +10,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -22,7 +21,6 @@
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use org\bovigo\vfs\vfsStream;
@@ -34,6 +32,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\FileOutputChannel;
 use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient;
 use WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Protocol1RuntimeCurrentStateClient.
@@ -48,8 +47,9 @@ use WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class Protocol1RuntimeCurrentStateClientTest extends \PHPUnit_Framework_TestCase
+class Protocol1RuntimeCurrentStateClientTest extends TestCase
 {
+
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient::__construct
      */
@@ -59,14 +59,11 @@ class Protocol1RuntimeCurrentStateClientTest extends \PHPUnit_Framework_TestCase
         $outputChannel = new FileOutputChannel();
 
         // Setup
-        $protocol1RuntimeCurrentStateClient =
-            new Protocol1RuntimeCurrentStateClient(
-                $serializer,
-                $outputChannel);
+        $protocol1RuntimeCurrentStateClient = new Protocol1RuntimeCurrentStateClient(
+                $serializer, $outputChannel);
 
         // Test
-        $this->assertInstanceOf('WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient',
-            $protocol1RuntimeCurrentStateClient);
+        $this->assertInstanceOf('WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient', $protocol1RuntimeCurrentStateClient);
     }
 
     /**
@@ -78,16 +75,16 @@ class Protocol1RuntimeCurrentStateClientTest extends \PHPUnit_Framework_TestCase
         // Setup
         $rootDirectory = 'root';
         $fileName = 'test';
-        $fileContents = '<?xml version="1.0" encoding="UTF-8"?>'."\n".
-            '<CurrentState>'.
-            '<StatusLease ClientId="clientId">'.
-            '<Acquire>'.
-            '<Incarnation>1</Incarnation>'.
-            '<Status>Recycle</Status>'.
-            '<Expiration>2000-01-01T00:00:00.0000000Z</Expiration>'.
-            '</Acquire>'.
-            '</StatusLease>'.
-            '</CurrentState>';
+        $fileContents = '<?xml version="1.0" encoding="UTF-8"?>' . "\n" .
+                '<CurrentState>' .
+                '<StatusLease ClientId="clientId">' .
+                '<Acquire>' .
+                '<Incarnation>1</Incarnation>' .
+                '<Status>Recycle</Status>' .
+                '<Expiration>2000-01-01T00:00:00.0000000Z</Expiration>' .
+                '</Acquire>' .
+                '</StatusLease>' .
+                '</CurrentState>';
 
         vfsStreamWrapper::register();
         vfsStreamWrapper::setRoot(new vfsStreamDirectory($rootDirectory));
@@ -98,32 +95,28 @@ class Protocol1RuntimeCurrentStateClientTest extends \PHPUnit_Framework_TestCase
         $serializer = new XmlCurrentStateSerializer();
         $fileOutputChannel = new FileOutputChannel();
 
-        $protocol1RuntimeCurrentStateClient =
-            new Protocol1RuntimeCurrentStateClient(
-                $serializer,
-                $fileOutputChannel
-            );
+        $protocol1RuntimeCurrentStateClient = new Protocol1RuntimeCurrentStateClient(
+                $serializer, $fileOutputChannel
+        );
 
         $protocol1RuntimeCurrentStateClient->setEndpoint(
-            vfsStream::url($rootDirectory.'/'.$fileName)
+                vfsStream::url($rootDirectory . '/' . $fileName)
         );
 
         // Test
         $recycleState = new AcquireCurrentState(
-            'clientId',
-            1,
-            CurrentStatus::RECYCLE,
-            new \DateTime('2000-01-01', new \DateTimeZone('UTC'))
+                'clientId', 1, CurrentStatus::RECYCLE, new \DateTime('2000-01-01', new \DateTimeZone('UTC'))
         );
 
         $protocol1RuntimeCurrentStateClient->setCurrentState($recycleState);
 
         $fileInputChannel = new FileInputChannel();
         $fileInputStream = $fileInputChannel->getInputStream(
-            vfsStream::url($rootDirectory.'/'.$fileName)
+                vfsStream::url($rootDirectory . '/' . $fileName)
         );
 
         $inputChannelContents = stream_get_contents($fileInputStream);
         $this->assertEquals($fileContents, $inputChannelContents);
     }
+
 }

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeGoalStateClientTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/Protocol1RuntimeGoalStateClientTest.php
@@ -33,6 +33,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeCurrentStateClient;
 use WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeGoalStateClient;
 use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Protocol1RuntimeGoalStateClient.
@@ -47,7 +48,7 @@ use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class Protocol1RuntimeGoalStateClientTest extends \PHPUnit_Framework_TestCase
+class Protocol1RuntimeGoalStateClientTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\Protocol1RuntimeGoalStateClient::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/ReleaseCurrentStateTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/ReleaseCurrentStateTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\ReleaseCurrentState;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class ReleaseCurrentState.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\ReleaseCurrentState;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class ReleaseCurrentStateTest extends \PHPUnit_Framework_TestCase
+class ReleaseCurrentStateTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\ReleaseCurrentState::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentConfigurationSettingChangeTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentConfigurationSettingChangeTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentConfigurationSettingChange;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleEnvironmentConfigurationSettingChange.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentConfigurationSettingChan
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleEnvironmentConfigurationSettingChangeTest extends \PHPUnit_Framework_TestCase
+class RoleEnvironmentConfigurationSettingChangeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentConfigurationSettingChange::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentDataTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentDataTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentData;
 use WindowsAzure\ServiceRuntime\Internal\RoleInstance;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleEnvironmentData.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\RoleInstance;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleEnvironmentDataTest extends \PHPUnit_Framework_TestCase
+class RoleEnvironmentDataTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentData::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentTopologyChangeTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleEnvironmentTopologyChangeTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentTopologyChange;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleEnvironmentTopologyChange.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentTopologyChange;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleEnvironmentTopologyChangeTest extends \PHPUnit_Framework_TestCase
+class RoleEnvironmentTopologyChangeTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentTopologyChange::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleInstanceEndpointTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleInstanceEndpointTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\RoleInstance;
 use WindowsAzure\ServiceRuntime\Internal\RoleInstanceEndpoint;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleInstanceEndpoint.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\RoleInstanceEndpoint;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleInstanceEndpointTest extends \PHPUnit_Framework_TestCase
+class RoleInstanceEndpointTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RoleInstanceEndpoint::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleInstanceTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleInstanceTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\Role;
 use WindowsAzure\ServiceRuntime\Internal\RoleInstance;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleInstance.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\RoleInstance;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleInstanceTest extends \PHPUnit_Framework_TestCase
+class RoleInstanceTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RoleInstance::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RoleTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\Role;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class Role.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\Role;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleTest extends \PHPUnit_Framework_TestCase
+class RoleTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\Role::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeKernelTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeKernelTest.php
@@ -26,6 +26,7 @@
 namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 use WindowsAzure\ServiceRuntime\Internal\RuntimeKernel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RuntimeKernel.
@@ -40,7 +41,7 @@ use WindowsAzure\ServiceRuntime\Internal\RuntimeKernel;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RuntimeKernelTest extends \PHPUnit_Framework_TestCase
+class RuntimeKernelTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RuntimeKernel::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeVersionManagerTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeVersionManagerTest.php
@@ -31,6 +31,7 @@ use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\RuntimeVersionProtocolClient;
 use WindowsAzure\ServiceRuntime\Internal\RuntimeVersionManager;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RuntimeVersionManager.
@@ -45,7 +46,7 @@ use WindowsAzure\ServiceRuntime\Internal\RuntimeVersionManager;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RuntimeVersionManagerTest extends \PHPUnit_Framework_TestCase
+class RuntimeVersionManagerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RuntimeVersionManager::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeVersionProtocolClientTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/RuntimeVersionProtocolClientTest.php
@@ -30,6 +30,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\RuntimeVersionProtocolClient;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RuntimeVersionProtocolClient.
@@ -44,7 +45,7 @@ use WindowsAzure\ServiceRuntime\Internal\RuntimeVersionProtocolClient;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RuntimeVersionProtocolClientTest extends \PHPUnit_Framework_TestCase
+class RuntimeVersionProtocolClientTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\RuntimeVersionProtocolClient::__construct

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlCurrentStateSerializerTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlCurrentStateSerializerTest.php
@@ -34,6 +34,7 @@ use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\FileOutputChannel;
 use WindowsAzure\ServiceRuntime\Internal\ReleaseCurrentState;
 use WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class XmlCurrentStateSerializer.
@@ -48,7 +49,7 @@ use WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class XmlCurrentStateSerializerTest extends \PHPUnit_Framework_TestCase
+class XmlCurrentStateSerializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\XmlCurrentStateSerializer::serialize

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlGoalStateDeserializerTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlGoalStateDeserializerTest.php
@@ -27,6 +27,7 @@ namespace Tests\unit\WindowsAzure\ServiceRuntime\Internal;
 
 
 use WindowsAzure\ServiceRuntime\Internal\XmlGoalStateDeserializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class XmlGoalStateDeserializer.
@@ -41,7 +42,7 @@ use WindowsAzure\ServiceRuntime\Internal\XmlGoalStateDeserializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class XmlGoalStateDeserializerTest extends \PHPUnit_Framework_TestCase
+class XmlGoalStateDeserializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\XmlGoalStateDeserializer::deserialize

--- a/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlRoleEnvironmentDataDeserializerTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/Internal/XmlRoleEnvironmentDataDeserializerTest.php
@@ -30,6 +30,7 @@ use org\bovigo\vfs\vfsStreamDirectory;
 use org\bovigo\vfs\vfsStreamWrapper;
 use WindowsAzure\ServiceRuntime\Internal\FileInputChannel;
 use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class XmlRoleEnvironmentDataDeserializer.
@@ -44,7 +45,7 @@ use WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class XmlRoleEnvironmentDataDeserializerTest extends \PHPUnit_Framework_TestCase
+class XmlRoleEnvironmentDataDeserializerTest extends TestCase
 {
     /**
      * @covers \WindowsAzure\ServiceRuntime\Internal\XmlRoleEnvironmentDataDeserializer::deserialize

--- a/tests/unit/WindowsAzure/ServiceRuntime/RoleEnvironmentTest.php
+++ b/tests/unit/WindowsAzure/ServiceRuntime/RoleEnvironmentTest.php
@@ -11,7 +11,7 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * 
+ *
  * PHP version 5
  *
  * @category  Microsoft
@@ -34,6 +34,7 @@ use WindowsAzure\ServiceRuntime\RoleEnvironment;
 use WindowsAzure\ServiceRuntime\Internal\RoleEnvironmentNotAvailableException;
 use WindowsAzure\ServiceRuntime\Internal\RoleInstanceStatus;
 use WindowsAzure\ServiceRuntime\Internal\RuntimeKernel;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Unit tests for class RoleEnvironment.
@@ -48,7 +49,7 @@ use WindowsAzure\ServiceRuntime\Internal\RuntimeKernel;
  *
  * @link      https://github.com/windowsazure/azure-sdk-for-php
  */
-class RoleEnvironmentTest extends \PHPUnit_Framework_TestCase
+class RoleEnvironmentTest extends TestCase
 {
     public function testRoleNotAvailable()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCases. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to require PHPUnit version [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.