### PR TITLE
Allow firebase/jwt to be installed in version 5.0 and above

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
         "php": ">=5.6",
         "pear/net_url2": "^2.2",
         "pear/mail_mime": "^1.10",
-        "firebase/php-jwt": "^4.0",
+        "firebase/php-jwt": "^4.0 || ^5.0",
         "microsoft/azure-storage": "^0.19.1",
         "guzzlehttp/guzzle": "^6.2",
         "zendframework/zend-mime": "^2.6",


### PR DESCRIPTION
[firebase/jwt](https://github.com/firebase/php-jwt)'s versioning scheme isn't ideal. However, version 5.0.0 bas been released on 2017-06-27. I've updated the composer.json to allow version 5.0.0 (and above) or version 4.0.0 (and above). Version requirement '^4.0' made it impossible to install the Azure SDK for PHP in projects that already required firebase/jwt in version '^>=5.0' in their own composer.json. 