### PR TITLE
Fix Issue 984 (getGuid bug)

### DIFF
--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -548,13 +548,13 @@ class Utilities
             mt_rand(0, 65535),
             mt_rand(0, 65535),          // 32 bits for "time_low"
             mt_rand(0, 65535),          // 16 bits for "time_mid"
-            mt_rand(0, 4096) + 16384,   // 16 bits for "time_hi_and_version", with
+            mt_rand(0, 4095) + 16384,   // 16 bits for "time_hi_and_version", with
                                         // the most significant 4 bits being 0100
                                         // to indicate randomly generated version
-            mt_rand(0, 64) + 128,       // 8 bits  for "clock_seq_hi", with
+            mt_rand(0, 63) + 128,       // 8 bits  for "clock_seq_hi", with
                                         // the most significant 2 bits being 10,
                                         // required by version 4 GUIDs.
-            mt_rand(0, 256),            // 8 bits  for "clock_seq_low"
+            mt_rand(0, 255),            // 8 bits  for "clock_seq_low"
             mt_rand(0, 65535),          // 16 bits for "node 0" and "node 1"
             mt_rand(0, 65535),          // 16 bits for "node 2" and "node 3"
             mt_rand(0, 65535)           // 16 bits for "node 4" and "node 5"

--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -537,27 +537,28 @@ class Utilities
      *
      * @static
      *
+     * @param string|function $rand  The random function to use.
      * @return string A new GUID
      */
-    public static function getGuid()
+    public static function getGuid($rand = 'mt_rand')
     {
         // @codingStandardsIgnoreStart
 
         return sprintf(
             '%04x%04x-%04x-%04x-%02x%02x-%04x%04x%04x',
-            mt_rand(0, 65535),
-            mt_rand(0, 65535),          // 32 bits for "time_low"
-            mt_rand(0, 65535),          // 16 bits for "time_mid"
-            mt_rand(0, 4095) + 16384,   // 16 bits for "time_hi_and_version", with
+            $rand(0, 65535),
+            $rand(0, 65535),            // 32 bits for "time_low"
+            $rand(0, 65535),            // 16 bits for "time_mid"
+            $rand(0, 4095) + 16384,     // 16 bits for "time_hi_and_version", with
                                         // the most significant 4 bits being 0100
                                         // to indicate randomly generated version
-            mt_rand(0, 63) + 128,       // 8 bits  for "clock_seq_hi", with
+            $rand(0, 63) + 128,         // 8 bits  for "clock_seq_hi", with
                                         // the most significant 2 bits being 10,
                                         // required by version 4 GUIDs.
-            mt_rand(0, 255),            // 8 bits  for "clock_seq_low"
-            mt_rand(0, 65535),          // 16 bits for "node 0" and "node 1"
-            mt_rand(0, 65535),          // 16 bits for "node 2" and "node 3"
-            mt_rand(0, 65535)           // 16 bits for "node 4" and "node 5"
+            $rand(0, 255),              // 8 bits  for "clock_seq_low"
+            $rand(0, 65535),            // 16 bits for "node 0" and "node 1"
+            $rand(0, 65535),            // 16 bits for "node 2" and "node 3"
+            $rand(0, 65535)             // 16 bits for "node 4" and "node 5"
         );
 
         // @codingStandardsIgnoreEnd

--- a/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
@@ -522,6 +522,34 @@ class UtilitiesTest extends TestCase
     }
 
     /**
+     * Testing the max & min of the range (by providing our own rand function)
+     * helps ensure that the function behaves accurately across the whole range.
+     * @covers \WindowsAzure\Common\Internal\Utilities::getGuid
+     */
+    public function testGetGuid_Min()
+    {
+        $func_min = function($min, $max) {
+            return $min;
+        };
+        $actual = Utilities::getGuid($func_min);
+        $this->assertEquals('00000000-0000-4000-8000-000000000000', $actual);
+    }
+
+    /**
+     * Testing the max & min of the range (by providing our own rand function)
+     * helps ensure that the function behaves accurately across the whole range.
+     * @covers \WindowsAzure\Common\Internal\Utilities::getGuid
+     */
+    public function testGetGuid_Max()
+    {
+        $func_max = function($min, $max) {
+            return $max;
+        };
+        $actual = Utilities::getGuid($func_max);
+        $this->assertEquals('ffffffff-ffff-4fff-bfff-ffffffffffff', $actual);
+    }
+
+    /**
      * @covers \WindowsAzure\Common\Internal\Utilities::endsWith
      */
     public function testEndsWith()


### PR DESCRIPTION
This pull request fixes #984.

As identified by @znrk (#984), getGuid() is broken.

In fact, it's not only broken on the line identified for clock_seq_low,
but also in 2 other places. mt_rand() is inclusive for both the max and
the min, so mt_rand(0, 256) produces a max value of 0x100 rather than
0xff, overflowing from 2 bits to 3 bits. The fix is simple - changing
the max value on the 3 lines where it's broken to ensure that the
generated GUID is in line with the spec for version 4 (random GUID) at
<https://tools.ietf.org/html/rfc4122>.

Note that I created a separate commit for the fix and for my tests. If you're opposed to merging my refactoring of getGuid(), I'm happy to create a pull request containing only the 3-line fix commit.