### PR TITLE
Add queryParams to MediaServices\MediaServicesRestProxy::getJobList

### DIFF
--- a/src/MediaServices/MediaServicesRestProxy.php
+++ b/src/MediaServices/MediaServicesRestProxy.php
@@ -1371,9 +1371,9 @@ class MediaServicesRestProxy extends ServiceRestProxy implements IMediaServices
      *
      * @return array of Models\Job
      */
-    public function getJobList()
+    public function getJobList(array $queryParams = [])
     {
-        $propertyList = $this->_getEntityList('Jobs');
+        $propertyList = $this->_getEntityList('Jobs', $queryParams);
         $result = [];
 
         foreach ($propertyList as $properties) {


### PR DESCRIPTION
queryParams gives you a possibility to make search request of Jobs with filters like $skip/$top/$filter.
It's useful when you have more then 1000 jobs.

Short example:
```
function viewJobs( int $offset = 0, int $limit = 1000, string $filter = '' ) {
        $params = [];
        if( $offset ) {
            $params[ '$skip' ] = $offset;
        }
        if( $limit ) {
            $params[ '$top' ] = $limit;
        } else {
            $params[ '$top' ] = 1000;
        }
        if( $filter ) {
            $params[ '$filter' ] = $filter;
        }
        $listIterator = $this->restProxy->getJobList( $params );
}

viewJobs( 1000, 0, "(false or (cast(State,'Edm.Int32') eq 0) or (cast(State,'Edm.Int32') eq 2) )" );
```

More about Jobs in official [Docs ](https://docs.microsoft.com/en-us/rest/api/media/operations/job#list_jobs)
