### PR TITLE
Drops mcrypt

### DIFF
--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -721,30 +721,13 @@ class Utilities
             sprintf(Resources::INVALID_STRING_LENGTH, 'initializationVector', '16')
         );
 
-        $blockCount = ceil(strlen($data) / 16);
-
-        $ctrData = '';
-        for ($i = 0; $i < $blockCount; ++$i) {
-            $ctrData .= $initializationVector;
-
-            // increment Initialization Vector
-            $j = 15;
-            do {
-                $digit = ord($initializationVector[$j]) + 1;
-                $initializationVector[$j] = chr($digit & 0xFF);
-
-                --$j;
-            } while (($digit == 0x100) && ($j >= 0));
-        }
-
-        $encryptCtrData = mcrypt_encrypt(
-            MCRYPT_RIJNDAEL_128,
+        return openssl_encrypt(
+            $data,
+            'aes-256-ctr',
             $key,
-            $ctrData,
-            MCRYPT_MODE_ECB
+            OPENSSL_RAW_DATA,
+            $initializationVector
         );
-
-        return $data ^ $encryptCtrData;
     }
 
     /**

--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -645,7 +645,12 @@ class Utilities
      */
     public static function generateCryptoKey($length)
     {
-        return openssl_random_pseudo_bytes($length);
+        if (function_exists('random_bytes'))
+        {
+            return random_bytes($length);
+        }
+        
+        openssl_random_pseudo_bytes($length);
     }
 
     /**
@@ -720,6 +725,12 @@ class Utilities
         return $result;
     }
 
+    /**
+     * Replace all hex characters in a string with lowercase
+     * and URL encode the resulting string.
+     * @param  string $str input string
+     * @return string URL Encoded string with 00-FF replaced with 00-ff
+     */
     public static function lowerUrlencode($str)
     {
         return preg_replace_callback('/%[0-9A-F]{2}/',

--- a/src/Common/Internal/Utilities.php
+++ b/src/Common/Internal/Utilities.php
@@ -532,8 +532,7 @@ class Utilities
      *
      * See http://tools.ietf.org/html/rfc4122 for more information.
      *
-     * Note: This function is available on all platforms, while the
-     * com_create_guid() is only available for Windows.
+     * Note: See https://stackoverflow.com/a/15875555
      *
      * @static
      *
@@ -541,26 +540,23 @@ class Utilities
      */
     public static function getGuid()
     {
-        // @codingStandardsIgnoreStart
+        $data = self::generateCryptoKey(16);
 
-        return sprintf(
-            '%04x%04x-%04x-%04x-%02x%02x-%04x%04x%04x',
-            mt_rand(0, 65535),
-            mt_rand(0, 65535),          // 32 bits for "time_low"
-            mt_rand(0, 65535),          // 16 bits for "time_mid"
-            mt_rand(0, 4096) + 16384,   // 16 bits for "time_hi_and_version", with
-                                        // the most significant 4 bits being 0100
-                                        // to indicate randomly generated version
-            mt_rand(0, 64) + 128,       // 8 bits  for "clock_seq_hi", with
-                                        // the most significant 2 bits being 10,
-                                        // required by version 4 GUIDs.
-            mt_rand(0, 256),            // 8 bits  for "clock_seq_low"
-            mt_rand(0, 65535),          // 16 bits for "node 0" and "node 1"
-            mt_rand(0, 65535),          // 16 bits for "node 2" and "node 3"
-            mt_rand(0, 65535)           // 16 bits for "node 4" and "node 5"
-        );
+        $data[6] = chr(ord($data[6]) & 0x0f | 0x40); // set version to 0100b = 4
+        $data[8] = chr(ord($data[8]) & 0x3f | 0x80); // set bits 6-7 to 10
 
-        // @codingStandardsIgnoreEnd
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($data), 4));
+    }
+
+
+    /**
+     * Generates a GUID provided a 16 byte pseudo random string
+     * @param  string $data 16 bytes long data string
+     * @return string A new GUID
+     */
+    private static function generateGuid($data)
+    {
+        return $guid;
     }
 
     /**

--- a/src/MediaServices/Models/ContentKey.php
+++ b/src/MediaServices/Models/ContentKey.php
@@ -402,12 +402,7 @@ class ContentKey
             $aesKey = $this->pkcs5_pad($aesKey, 16);
         }
 
-        $encrypted = mcrypt_encrypt(
-            MCRYPT_RIJNDAEL_128, // AES
-            $aesKey,
-            $this->_id,
-            MCRYPT_MODE_ECB
-        );
+        $encrypted = openssl_encrypt($this->_id, 'aes-256-ecb', $aesKey, OPENSSL_RAW_DATA);
 
         $this->_checksum = base64_encode(substr($encrypted, 0, 8));
     }

--- a/tests/framework/MediaServicesRestProxyTestBase.php
+++ b/tests/framework/MediaServicesRestProxyTestBase.php
@@ -45,6 +45,7 @@ use WindowsAzure\MediaServices\Models\ProgramState;
 use WindowsAzure\Common\Internal\Http\Url;
 use WindowsAzure\Common\Internal\Http\HttpClient;
 use WindowsAzure\Common\Internal\Resources;
+use WindowsAzure\Common\Internal\Utilities;
 
 /**
  * TestBase class for each unit test class.
@@ -419,7 +420,7 @@ class MediaServicesRestProxyTestBase extends ServiceRestProxyTestBase
 
     protected function createSuffix()
     {
-        return sprintf('-%04x', mt_rand(0, 65535));
+        return sprintf('-%04x', Utilities::generateRandomInt(0, 65535));
     }
 
     protected function createLargeFile()

--- a/tests/framework/RestProxyTestBase.php
+++ b/tests/framework/RestProxyTestBase.php
@@ -28,6 +28,7 @@ namespace Tests\framework;
 
 use WindowsAzure\Common\Internal\Logger;
 use WindowsAzure\Common\Internal\Serialization\XmlSerializer;
+use WindowsAzure\Common\Internal\Utilities;
 use WindowsAzure\Common\ServicesBuilder;
 use PHPUnit\Framework\TestCase;
 
@@ -52,7 +53,7 @@ class RestProxyTestBase extends TestCase
 
     protected function getTestName()
     {
-        return sprintf('onesdkphp%04x', mt_rand(0, 65535));
+        return sprintf('onesdkphp%04x', Utilities::generateRandomInt(0, 65535));
     }
 
     public static function assertHandler($file, $line, $code)

--- a/tests/functional/WindowsAzure/BlobServiceFunctionalTestData.php
+++ b/tests/functional/WindowsAzure/BlobServiceFunctionalTestData.php
@@ -47,6 +47,7 @@ use MicrosoftAzure\Storage\Common\Models\Logging;
 use MicrosoftAzure\Storage\Common\Models\Metrics;
 use MicrosoftAzure\Storage\Common\Models\RetentionPolicy;
 use MicrosoftAzure\Storage\Common\Models\ServiceProperties;
+use WindowsAzure\Common\Internal\Utilities;
 
 class BlobServiceFunctionalTestData
 {
@@ -61,7 +62,7 @@ class BlobServiceFunctionalTestData
 
     public static function setupData($accountName)
     {
-        $rInt = mt_rand(0, 1000000);
+        $rInt = Utilities::generateRandomInt(0, 1000000);
         self::$_accountName = $accountName;
         self::$testUniqueId = 'qa-'.$rInt.'-';
         self::$nonExistContainerPrefix = 'qa-'.($rInt. 1).'-';

--- a/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/UtilitiesTest.php
@@ -605,8 +605,8 @@ class UtilitiesTest extends TestCase
         $initializationVector = str_pad($efectiveInitializationVector, 16, chr(255));
 
         // Test
-        $ecnrypted = Utilities::ctrCrypt($data, $key, $initializationVector);
-        $decrypted = Utilities::ctrCrypt($ecnrypted, $key, $initializationVector);
+        $encrypted = Utilities::ctrCrypt($data, $key, $initializationVector);
+        $decrypted = Utilities::ctrCrypt($encrypted, $key, $initializationVector);
 
         // Assert
         $this->assertEquals($data, $decrypted);


### PR DESCRIPTION
- This clears the way for PHP7.2 support.
- Fixes https://github.com/Azure/azure-sdk-for-php/issues/918
- Uses same code as https://github.com/paragonie/random_compat as a `random_int` polyfill (I'm running 7.2 and the upgrade is painful till phpdocumentor has a compatible release, so I didn't use the package instead) - Can take this up if really necessary.
- `mcrypt_encrypt` changes are not tested as thoroughly as I'd like (help is appreciated)