### PR TITLE
Parse EntityPath in Service Bus connection strings

### DIFF
--- a/src/Common/Internal/Resources.php
+++ b/src/Common/Internal/Resources.php
@@ -61,6 +61,7 @@ class Resources {
     const CERTIFICATE_PATH_NAME = 'CertificatePath';
     const SERVICE_MANAGEMENT_ENDPOINT_NAME = 'ServiceManagementEndpoint';
     const SERVICE_BUS_ENDPOINT_NAME = 'Endpoint';
+    const SERVICE_BUS_ENTITY_PATH = 'EntityPath';
     const SHARED_SECRET_ISSUER_NAME = 'SharedSecretIssuer';
     const SHARED_SECRET_VALUE_NAME = 'SharedSecretValue';
     const SHARED_SHARED_ACCESS_KEY_NAME = 'SharedAccessKeyName';

--- a/src/Common/Internal/ServiceBusSettings.php
+++ b/src/Common/Internal/ServiceBusSettings.php
@@ -50,6 +50,11 @@ class ServiceBusSettings extends ServiceSettings {
     private $_serviceBusEndpointUri;
 
     /**
+     * @var string|null
+     */
+    private $_serviceBusEntityPath;
+
+    /**
      * @var string
      */
     private $_wrapEndpointUri;
@@ -91,6 +96,13 @@ class ServiceBusSettings extends ServiceSettings {
     private static $_serviceBusEndpointSetting;
 
     /**
+     * Validator for the EntityPath setting.
+     *
+     * @var array
+     */
+    private static $_serviceBusEntityPathSetting;
+
+    /**
      * Validator for the StsEndpoint setting. Must be a valid Uri.
      *
      * @var array
@@ -128,6 +140,10 @@ class ServiceBusSettings extends ServiceSettings {
             Validate::getIsValidUri()
         );
 
+        self::$_serviceBusEntityPathSetting = self::setting(
+            Resources::SERVICE_BUS_ENTITY_PATH
+        );
+
         self::$_wrapNameSetting = self::setting(
             Resources::SHARED_SECRET_ISSUER_NAME
         );
@@ -150,6 +166,7 @@ class ServiceBusSettings extends ServiceSettings {
         );
 
         self::$validSettingKeys[] = Resources::SERVICE_BUS_ENDPOINT_NAME;
+        self::$validSettingKeys[] = Resources::SERVICE_BUS_ENTITY_PATH;
         self::$validSettingKeys[] = Resources::SHARED_SECRET_ISSUER_NAME;
         self::$validSettingKeys[] = Resources::SHARED_SECRET_VALUE_NAME;
         self::$validSettingKeys[] = Resources::SHARED_SHARED_ACCESS_KEY_NAME;
@@ -161,14 +178,16 @@ class ServiceBusSettings extends ServiceSettings {
      * Creates new Service Bus settings instance.
      * @param type $serviceBusEndpoint The Service Bus endpoint uri
      * @param type $filter
+     * @param string $serviceBusEntityPath
      */
     public function __construct(
         $serviceBusEndpoint,
-        $filter
+        $filter,
+        $serviceBusEntityPath = null
     ) {
         $this->_serviceBusEndpointUri = $serviceBusEndpoint;
         $this->_filter = $filter;
-
+        $this->_serviceBusEntityPath = $serviceBusEntityPath;
     }
 
     /**
@@ -182,6 +201,7 @@ class ServiceBusSettings extends ServiceSettings {
             self::$_wrapPasswordSetting,
         ];
         $optional = [
+            self::$_serviceBusEntityPathSetting,
             self::$_wrapEndpointUriSetting,
         ];
 
@@ -189,6 +209,10 @@ class ServiceBusSettings extends ServiceSettings {
 
         $endpoint = Utilities::tryGetValueInsensitive(
             Resources::SERVICE_BUS_ENDPOINT_NAME,
+            $tokenizedSettings
+        );
+        $entityPath = Utilities::tryGetValueInsensitive(
+            Resources::SERVICE_BUS_ENTITY_PATH,
             $tokenizedSettings
         );
 
@@ -214,7 +238,7 @@ class ServiceBusSettings extends ServiceSettings {
             $issuerName,
             $issuerValue,
             self::createWrapService($wrapEndpointUri)
-        ));
+        ), $entityPath);
     }
     /**
      * @param array $tokenizedSettings
@@ -227,12 +251,17 @@ class ServiceBusSettings extends ServiceSettings {
             self::$_sasKeySetting,
         ];
         $optional = [
+            self::$_serviceBusEntityPathSetting,
             self::$_wrapEndpointUriSetting,
         ];
         $matchedSpecs = self::getMatchedSpecs($tokenizedSettings, $required, $optional, $connectionString);
 
         $endpoint = Utilities::tryGetValueInsensitive(
             Resources::SERVICE_BUS_ENDPOINT_NAME,
+            $tokenizedSettings
+        );
+        $entityPath = Utilities::tryGetValueInsensitive(
+            Resources::SERVICE_BUS_ENTITY_PATH,
             $tokenizedSettings
         );
 
@@ -248,7 +277,7 @@ class ServiceBusSettings extends ServiceSettings {
         return new self($endpoint, new SASFilter(
             $sharedAccessKeyName,
             $sharedAccessKey
-        ));
+        ), $entityPath);
     }
     /**
      * @param $wrapEndpointUri
@@ -303,6 +332,15 @@ class ServiceBusSettings extends ServiceSettings {
      */
     public function getServiceBusEndpointUri() {
         return $this->_serviceBusEndpointUri;
+    }
+
+    /**
+     * Gets the Service Bus entity path.
+     *
+     * @return string|null
+     */
+    public function getServiceBusEntityPath() {
+        return $this->_serviceBusEntityPath;
     }
 
     /**

--- a/tests/unit/WindowsAzure/Common/Internal/ServiceBusSettingsTest.php
+++ b/tests/unit/WindowsAzure/Common/Internal/ServiceBusSettingsTest.php
@@ -129,7 +129,7 @@ class ServiceBusSettingsTest extends TestCase
         $expectedMsg = sprintf(
             Resources::INVALID_CONNECTION_STRING_SETTING_KEY,
             $invalidKey,
-            implode("\n", ['Endpoint', 'SharedSecretIssuer', 'SharedSecretValue'])
+            implode("\n", ['Endpoint', 'EntityPath', 'SharedSecretIssuer', 'SharedSecretValue'])
         );
         $this->setExpectedException('\RuntimeException', $expectedMsg);
 
@@ -182,15 +182,16 @@ class ServiceBusSettingsTest extends TestCase
      * @covers \WindowsAzure\Common\Internal\ServiceSettings::parseAndValidateKeys
      * @covers \WindowsAzure\Common\Internal\ServiceSettings::noMatch
      */
-    public function testCreateFromConnectionStringWithCaseInvesitive()
+    public function testCreateFromConnectionStringWithCaseInsensitive()
     {
         // Setup
-        $namepspace = 'mynamespace';
-        $expectedServiceBusEndpoint = "https://$namepspace.servicebus.windows.net";
+        $namespace = 'mynamespace';
+        $expectedServiceBusEndpoint = "https://$namespace.servicebus.windows.net";
+        $expectedServiceBusEntityPath = 'myqueue';
         $expectedWrapName = 'myname';
         $expectedWrapPassword = 'mypassword';
-        $expectedWrapEndpointUri = "https://$namepspace-sb.accesscontrol.windows.net/WRAPv0.9";
-        $connectionString = "eNdPoinT=$expectedServiceBusEndpoint;sHarEdsecRetiSsuer=$expectedWrapName;shArEdsecrEtvAluE=$expectedWrapPassword";
+        $expectedWrapEndpointUri = "https://$namespace-sb.accesscontrol.windows.net/WRAPv0.9";
+        $connectionString = "eNdPoinT=$expectedServiceBusEndpoint;sHarEdsecRetiSsuer=$expectedWrapName;shArEdsecrEtvAluE=$expectedWrapPassword;eNtItYpAtH=$expectedServiceBusEntityPath";
 
         // Test
         $actual = ServiceBusSettings::createFromConnectionString($connectionString);
@@ -198,6 +199,7 @@ class ServiceBusSettingsTest extends TestCase
         // Assert
         $this->assertInstanceOf('WindowsAzure\Common\Internal\IServiceFilter', $actual->getFilter());
         $this->assertEquals($expectedServiceBusEndpoint, $actual->getServiceBusEndpointUri());
+        $this->assertEquals($expectedServiceBusEntityPath, $actual->getServiceBusEntityPath());
     }
 
     /**


### PR DESCRIPTION
The connection strings shown in the Azure Portal may include a `EntityPath` if the SAS key is tied to a specific queue. This patch extends the parser and adds a method to access the entity path. It does not introduce any BC breaks.