### PR TITLE
Consume messages from dead-letter

### DIFF
--- a/src/Common/Internal/Resources.php
+++ b/src/Common/Internal/Resources.php
@@ -408,7 +408,9 @@ class Resources {
     const LIST_RULES_PATH = '%s/subscriptions/%s/rules';
     const LIST_SUBSCRIPTIONS_PATH = '%s/subscriptions';
     const RECEIVE_MESSAGE_PATH = '%s/messages/head';
+    const RECEIVE_MESSAGE_DEADLETTER_PATH = '%s/$DeadLetterQueue/messages/head';
     const RECEIVE_SUBSCRIPTION_MESSAGE_PATH = '%s/subscriptions/%s/messages/head';
+    const RECEIVE_SUBSCRIPTION_MESSAGE_DEADLETTER_PATH = '%s/subscriptions/%s/$DeadLetterQueue/messages/head';
     const SEND_MESSAGE_PATH = '%s/messages';
     const RULE_PATH = '%s/subscriptions/%s/rules/%s';
     const SUBSCRIPTION_PATH = '%s/subscriptions/%s';

--- a/src/ServiceBus/Models/ReceiveMessageOptions.php
+++ b/src/ServiceBus/Models/ReceiveMessageOptions.php
@@ -54,6 +54,13 @@ class ReceiveMessageOptions
     private $_receiveMode;
 
     /**
+     * Flag to receive from deadletter instead
+     *
+     * @var bool
+     */
+    private $deadLetter = false;
+
+    /**
      * Creates a receive message option instance with default parameters.
      */
     public function __construct()
@@ -134,5 +141,23 @@ class ReceiveMessageOptions
     public function setPeekLock()
     {
         $this->_receiveMode = ReceiveMode::PEEK_LOCK;
+    }
+
+    /**
+     * Enable deadletter flag
+     */
+    public function setDeadLetter()
+    {
+        $this->deadLetter = true;
+    }
+
+    /**
+     * Get deadletter flag
+     *
+     * @return bool
+     */
+    public function getDeadLetter()
+    {
+        return $this->deadLetter;
     }
 }

--- a/src/ServiceBus/ServiceBusRestProxy.php
+++ b/src/ServiceBus/ServiceBusRestProxy.php
@@ -166,7 +166,12 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
         $queueName,
         ReceiveMessageOptions $receiveMessageOptions = null
     ) {
-        $queueMessagePath = sprintf(Resources::RECEIVE_MESSAGE_PATH, $queueName);
+        $pathFormat = Resources::RECEIVE_MESSAGE_PATH;
+        if ($receiveMessageOptions->getDeadLetter()) {
+            $pathFormat = Resources::RECEIVE_MESSAGE_DEADLETTER_PATH;
+        }
+
+        $queueMessagePath = sprintf($pathFormat, $queueName);
 
         return $this->receiveMessage(
             $queueMessagePath,
@@ -300,8 +305,13 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
         $subscriptionName,
         ReceiveMessageOptions $receiveMessageOptions = null
     ) {
+        $pathFormat = Resources::RECEIVE_SUBSCRIPTION_MESSAGE_PATH;
+        if ($receiveMessageOptions->getDeadLetter()) {
+            $pathFormat = Resources::RECEIVE_SUBSCRIPTION_MESSAGE_DEADLETTER_PATH;
+        }
+
         $messagePath = sprintf(
-            Resources::RECEIVE_SUBSCRIPTION_MESSAGE_PATH,
+            $pathFormat,
             $topicName,
             $subscriptionName
         );

--- a/tests/unit/WindowsAzure/ServiceBus/models/ReceiveMessageOptionsTest.php
+++ b/tests/unit/WindowsAzure/ServiceBus/models/ReceiveMessageOptionsTest.php
@@ -98,4 +98,32 @@ class ReceiveMessageOptionsTest extends TestCase
             $actual
         );
     }
+
+    /**
+     * @covers \WindowsAzure\ServiceBus\Models\ReceiveMessageOptions::getDeadLetter
+     * @covers \WindowsAzure\ServiceBus\Models\ReceiveMessageOptions::setDeadLetter
+     */
+    public function testGetSetDeadLetter()
+    {
+        // Setup
+        $receiveMessageOptions = new ReceiveMessageOptions();
+
+        // Test
+        $receiveMessageOptions->setDeadLetter();
+
+        // Assert
+        $this->assertTrue($receiveMessageOptions->getDeadLetter());
+    }
+
+    /**
+     * @covers \WindowsAzure\ServiceBus\Models\ReceiveMessageOptions::getDeadLetter
+     */
+    public function testGetDeadLetterByDefault()
+    {
+        // Setup
+        $receiveMessageOptions = new ReceiveMessageOptions();
+
+        // Assert
+        $this->assertFalse($receiveMessageOptions->getDeadLetter());
+    }
 }


### PR DESCRIPTION
Hello,

I came across the dead-letter use case in one project and didn't find official documentation about how to consume messages from dead-letter queue in the PHP SDK. From https://stackoverflow.com/a/34343745, I've tested adding `$DeadLetterQueue` to the queue and topic paths.

I've tested in one project and It worked. Please let me know your thoughts about the changes. If you are considering them, I can continue working on the `ServiceBusRestProxyTest` tests and also add some documentation afterwards.