### PR TITLE
Correct the return type of receiveQueueMessage()

### DIFF
--- a/src/ServiceBus/Internal/IServiceBus.php
+++ b/src/ServiceBus/Internal/IServiceBus.php
@@ -88,7 +88,7 @@ interface IServiceBus extends FilterableService
      *
      * @throws Exception
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveQueueMessage($queueName, ReceiveMessageOptions $receivedMessageOptions = null);
 

--- a/src/ServiceBus/ServiceBusRestProxy.php
+++ b/src/ServiceBus/ServiceBusRestProxy.php
@@ -160,7 +160,7 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
      * @param ReceiveMessageOptions|null $receiveMessageOptions The options to
      *                                                          receive the message
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveQueueMessage(
         $queueName,
@@ -193,7 +193,7 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
      * @param ReceiveMessageOptions $receiveMessageOptions The options to
      *                                                     receive the message
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveMessage($path, ReceiveMessageOptions $receiveMessageOptions = null)
     {


### PR DESCRIPTION
It looks #494 changed the return type to be nullable (in case there are no messages in the queue to receive), so this PR corrects the declared return type so that calling code knows it needs to handle the `null` return type