### PR TITLE
add some missing null types in phpdoc

### DIFF
--- a/src/ServiceBus/Internal/IServiceBus.php
+++ b/src/ServiceBus/Internal/IServiceBus.php
@@ -88,7 +88,7 @@ interface IServiceBus extends FilterableService
      *
      * @throws Exception
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveQueueMessage($queueName, ReceiveMessageOptions $receivedMessageOptions = null);
 
@@ -102,7 +102,7 @@ interface IServiceBus extends FilterableService
      *
      * @throws Exception
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveMessage($path, ReceiveMessageOptions $receiveMessageOptions);
 
@@ -128,7 +128,7 @@ interface IServiceBus extends FilterableService
      *
      * @throws Exception
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveSubscriptionMessage(
         $topicName,

--- a/src/ServiceBus/Models/BrokerProperties.php
+++ b/src/ServiceBus/Models/BrokerProperties.php
@@ -45,105 +45,105 @@ class BrokerProperties
     /**
      * The correlation ID.
      *
-     * @var string
+     * @var string|null
      */
     private $_correlationId;
 
     /**
      * The session ID.
      *
-     * @var string
+     * @var string|null
      */
     private $_sessionId;
 
     /**
      * The delivery count.
      *
-     * @var int
+     * @var int|null
      */
     private $_deliveryCount;
 
     /**
      * The locked until time.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      */
     private $_lockedUntilUtc;
 
     /**
      * The lock token.
      *
-     * @var string
+     * @var string|null
      */
     private $_lockToken;
 
     /**
      * The message Id.
      *
-     * @var string
+     * @var string|null
      */
     private $_messageId;
 
     /**
      * The label.
      *
-     * @var string
+     * @var string|null
      */
     private $_label;
 
     /**
      * The reply to.
      *
-     * @var string
+     * @var string|null
      */
     private $_replyTo;
 
     /**
      * The sequence number.
      *
-     * @var string
+     * @var int|null
      */
     private $_sequenceNumber;
 
     /**
      * The time to live.
      *
-     * @var float
+     * @var float|null
      */
     private $_timeToLive;
 
     /**
      * The to.
      *
-     * @var string
+     * @var string|null
      */
     private $_to;
 
     /**
      * The scheduled enqueue time.
      *
-     * @var \DateTime
+     * @var \DateTime|null
      */
     private $_scheduledEnqueueTimeUtc;
 
     /**
      * The reply to session ID.
      *
-     * @var string
+     * @var string|null
      */
     private $_replyToSessionId;
 
     /**
      * The location of the message.
      *
-     * @var string
+     * @var string|null
      */
     private $_messageLocation;
 
     /**
      * The location of the lock.
      *
-     * @var string
+     * @var string|null
      */
     private $_lockLocation;
 
@@ -274,7 +274,7 @@ class BrokerProperties
     /**
      * Gets the correlation ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getCorrelationId()
     {
@@ -284,7 +284,7 @@ class BrokerProperties
     /**
      * Sets the correlation ID.
      *
-     * @param string $correlationId The correlation ID
+     * @param string|null $correlationId The correlation ID
      */
     public function setCorrelationId($correlationId)
     {
@@ -294,7 +294,7 @@ class BrokerProperties
     /**
      * Gets the session ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getSessionId()
     {
@@ -304,7 +304,7 @@ class BrokerProperties
     /**
      * Sets the session ID.
      *
-     * @param string $sessionId The ID of the session
+     * @param string|null $sessionId The ID of the session
      */
     public function setSessionId($sessionId)
     {
@@ -314,7 +314,7 @@ class BrokerProperties
     /**
      * Gets the delivery count.
      *
-     * @return int
+     * @return int|null
      */
     public function getDeliveryCount()
     {
@@ -324,7 +324,7 @@ class BrokerProperties
     /**
      * Sets the delivery count.
      *
-     * @param int $deliveryCount The count of the delivery
+     * @param int|null $deliveryCount The count of the delivery
      */
     public function setDeliveryCount($deliveryCount)
     {
@@ -334,7 +334,7 @@ class BrokerProperties
     /**
      * Gets the locked until time.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getLockedUntilUtc()
     {
@@ -344,7 +344,7 @@ class BrokerProperties
     /**
      * Sets the locked until time.
      *
-     * @param \DateTime $lockedUntilUtc The locked until time
+     * @param \DateTime|null $lockedUntilUtc The locked until time
      */
     public function setLockedUntilUtc(\DateTime $lockedUntilUtc)
     {
@@ -354,7 +354,7 @@ class BrokerProperties
     /**
      * Gets lock token.
      *
-     * @return string
+     * @return string|null
      */
     public function getLockToken()
     {
@@ -364,7 +364,7 @@ class BrokerProperties
     /**
      * Sets the lock token.
      *
-     * @param string $lockToken The lock token
+     * @param string|null $lockToken The lock token
      */
     public function setLockToken($lockToken)
     {
@@ -374,7 +374,7 @@ class BrokerProperties
     /**
      * Gets the message ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getMessageId()
     {
@@ -384,7 +384,7 @@ class BrokerProperties
     /**
      * Sets the message ID.
      *
-     * @param string $messageId The ID of the message
+     * @param string|null $messageId The ID of the message
      */
     public function setMessageId($messageId)
     {
@@ -394,7 +394,7 @@ class BrokerProperties
     /**
      * Gets the label.
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -404,7 +404,7 @@ class BrokerProperties
     /**
      * Sets the label.
      *
-     * @param string $label The label of the broker property
+     * @param string|null $label The label of the broker property
      */
     public function setLabel($label)
     {
@@ -414,7 +414,7 @@ class BrokerProperties
     /**
      * Gets the reply to.
      *
-     * @return string
+     * @return string|null
      */
     public function getReplyTo()
     {
@@ -424,7 +424,7 @@ class BrokerProperties
     /**
      * Sets the reply to.
      *
-     * @param string $replyTo The reply to
+     * @param string|null $replyTo The reply to
      */
     public function setReplyTo($replyTo)
     {
@@ -434,7 +434,7 @@ class BrokerProperties
     /**
      * Gets the sequence number.
      *
-     * @return int
+     * @return int|null
      */
     public function getSequenceNumber()
     {
@@ -444,7 +444,7 @@ class BrokerProperties
     /**
      * Sets the sequence number.
      *
-     * @param int $sequenceNumber The sequence number
+     * @param int|null $sequenceNumber The sequence number
      */
     public function setSequenceNumber($sequenceNumber)
     {
@@ -454,7 +454,7 @@ class BrokerProperties
     /**
      * Gets time to live.
      *
-     * @return string
+     * @return float|null
      */
     public function getTimeToLive()
     {
@@ -464,7 +464,7 @@ class BrokerProperties
     /**
      * Sets time to live.
      *
-     * @param string $timeToLive The time to live
+     * @param float|null $timeToLive The time to live
      */
     public function setTimeToLive($timeToLive)
     {
@@ -474,7 +474,7 @@ class BrokerProperties
     /**
      * Gets to.
      *
-     * @return string
+     * @return string|null
      */
     public function getTo()
     {
@@ -484,7 +484,7 @@ class BrokerProperties
     /**
      * Sets to.
      *
-     * @param string $to To
+     * @param string|null $to To
      */
     public function setTo($to)
     {
@@ -494,7 +494,7 @@ class BrokerProperties
     /**
      * Gets scheduled enqueue time UTC.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getScheduledEnqueueTimeUtc()
     {
@@ -504,7 +504,7 @@ class BrokerProperties
     /**
      * Sets scheduled enqueue time UTC.
      *
-     * @param \DateTime $scheduledEnqueueTimeUtc The scheduled enqueue time
+     * @param \DateTime|null $scheduledEnqueueTimeUtc The scheduled enqueue time
      */
     public function setScheduledEnqueueTimeUtc(\DateTime $scheduledEnqueueTimeUtc)
     {
@@ -514,7 +514,7 @@ class BrokerProperties
     /**
      * Gets reply to session ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getReplyToSessionId()
     {
@@ -524,7 +524,7 @@ class BrokerProperties
     /**
      * Sets reply to session.
      *
-     * @param string $replyToSessionId reply to session
+     * @param string|null $replyToSessionId reply to session
      */
     public function setReplyToSessionId($replyToSessionId)
     {
@@ -534,7 +534,7 @@ class BrokerProperties
     /**
      * Gets message location.
      *
-     * @return string
+     * @return string|null
      */
     public function getMessageLocation()
     {
@@ -544,7 +544,7 @@ class BrokerProperties
     /**
      * Sets the location of the message.
      *
-     * @param string $messageLocation The location of the message
+     * @param string|null $messageLocation The location of the message
      */
     public function setMessageLocation($messageLocation)
     {
@@ -554,7 +554,7 @@ class BrokerProperties
     /**
      * Gets the location of the lock.
      *
-     * @return string
+     * @return string|null
      */
     public function getLockLocation()
     {
@@ -564,7 +564,7 @@ class BrokerProperties
     /**
      * Sets the location of the lock.
      *
-     * @param string $lockLocation The location of the lock
+     * @param string|null $lockLocation The location of the lock
      */
     public function setLockLocation($lockLocation)
     {

--- a/src/ServiceBus/Models/BrokeredMessage.php
+++ b/src/ServiceBus/Models/BrokeredMessage.php
@@ -58,14 +58,14 @@ class BrokeredMessage
     /**
      * The content type of the brokered message.
      *
-     * @var string
+     * @var string|null
      */
     private $_contentType;
 
     /**
      * The date of the brokered message.
      *
-     * @var string
+     * @var string|null
      */
     private $_date;
 
@@ -132,7 +132,7 @@ class BrokeredMessage
     /**
      * Gets the content type of the brokered message.
      *
-     * @return string
+     * @return string|null
      */
     public function getContentType()
     {
@@ -142,7 +142,7 @@ class BrokeredMessage
     /**
      * Sets the content type of the brokered message.
      *
-     * @param string $contentType The content type of
+     * @param string|null $contentType The content type of
      *                            the brokered message
      */
     public function setContentType($contentType)
@@ -153,7 +153,7 @@ class BrokeredMessage
     /**
      * Gets the date of the brokered message.
      *
-     * @return string
+     * @return string|null
      */
     public function getDate()
     {
@@ -163,7 +163,7 @@ class BrokeredMessage
     /**
      * Sets the date of the brokered message.
      *
-     * @param string $date Sets the date of the brokered message
+     * @param string|null $date Sets the date of the brokered message
      */
     public function setDate($date)
     {
@@ -211,7 +211,7 @@ class BrokeredMessage
     /**
      * Gets the delivery count.
      *
-     * @return int
+     * @return int|null
      */
     public function getDeliveryCount()
     {
@@ -221,7 +221,7 @@ class BrokeredMessage
     /**
      * Sets the delivery count.
      *
-     * @param int $deliveryCount The times that the message has been delivered
+     * @param int|null $deliveryCount The times that the message has been delivered
      */
     public function setDeliveryCount($deliveryCount)
     {
@@ -231,7 +231,7 @@ class BrokeredMessage
     /**
      * Gets the ID of the message.
      *
-     * @return string
+     * @return string|null
      */
     public function getMessageId()
     {
@@ -241,7 +241,7 @@ class BrokeredMessage
     /**
      * Sets the ID of the message.
      *
-     * @param string $messageId The ID of the message
+     * @param string|null $messageId The ID of the message
      */
     public function setMessageId($messageId)
     {
@@ -251,7 +251,7 @@ class BrokeredMessage
     /**
      * Gets the sequence number.
      *
-     * @return int
+     * @return int|null
      */
     public function getSequenceNumber()
     {
@@ -261,7 +261,7 @@ class BrokeredMessage
     /**
      * Sets the sequence number.
      *
-     * @param int $sequenceNumber The sequence number
+     * @param int|null $sequenceNumber The sequence number
      */
     public function setSequenceNumber($sequenceNumber)
     {
@@ -271,7 +271,7 @@ class BrokeredMessage
     /**
      * Gets the time to live.
      *
-     * @return string
+     * @return float|null
      */
     public function getTimeToLive()
     {
@@ -281,7 +281,7 @@ class BrokeredMessage
     /**
      * Sets the time to live.
      *
-     * @param string $timeToLive The time to live
+     * @param float|null $timeToLive The time to live
      */
     public function setTimeToLive($timeToLive)
     {
@@ -291,7 +291,7 @@ class BrokeredMessage
     /**
      * Gets the lock token.
      *
-     * @return string
+     * @return string|null
      */
     public function getLockToken()
     {
@@ -301,7 +301,7 @@ class BrokeredMessage
     /**
      * Sets the lock token.
      *
-     * @param string $lockToken The token of the lock
+     * @param string|null $lockToken The token of the lock
      */
     public function setLockToken($lockToken)
     {
@@ -311,7 +311,7 @@ class BrokeredMessage
     /**
      * Gets the time of locked until UTC.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getLockedUntilUtc()
     {
@@ -331,7 +331,7 @@ class BrokeredMessage
     /**
      * Gets the correlation ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getCorrelationId()
     {
@@ -341,7 +341,7 @@ class BrokeredMessage
     /**
      * Sets the correlation ID.
      *
-     * @param string $correlationId The ID of the correlation
+     * @param string|null $correlationId The ID of the correlation
      */
     public function setCorrelationId($correlationId)
     {
@@ -351,7 +351,7 @@ class BrokeredMessage
     /**
      * Gets the session ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getSessionId()
     {
@@ -361,7 +361,7 @@ class BrokeredMessage
     /**
      * Sets the session ID.
      *
-     * @param string $sessionId The ID of the session
+     * @param string|null $sessionId The ID of the session
      */
     public function setSessionId($sessionId)
     {
@@ -371,7 +371,7 @@ class BrokeredMessage
     /**
      * Gets the label.
      *
-     * @return string
+     * @return string|null
      */
     public function getLabel()
     {
@@ -381,7 +381,7 @@ class BrokeredMessage
     /**
      * Sets the label.
      *
-     * @param string $label The label of the broker properties
+     * @param string|null $label The label of the broker properties
      */
     public function setLabel($label)
     {
@@ -391,7 +391,7 @@ class BrokeredMessage
     /**
      * Gets reply to.
      *
-     * @return string
+     * @return string|null
      */
     public function getReplyTo()
     {
@@ -401,7 +401,7 @@ class BrokeredMessage
     /**
      * Sets the reply to.
      *
-     * @param string $replyTo The reply to value
+     * @param string|null $replyTo The reply to value
      */
     public function setReplyTo($replyTo)
     {
@@ -411,7 +411,7 @@ class BrokeredMessage
     /**
      * Gets to.
      *
-     * @return string
+     * @return string|null
      */
     public function getTo()
     {
@@ -421,7 +421,7 @@ class BrokeredMessage
     /**
      * Sets the to.
      *
-     * @param string $to to
+     * @param string|null $to to
      */
     public function setTo($to)
     {
@@ -431,7 +431,7 @@ class BrokeredMessage
     /**
      * Gets the scheduled enqueue time.
      *
-     * @return \DateTime
+     * @return \DateTime|null
      */
     public function getScheduledEnqueueTimeUtc()
     {
@@ -451,7 +451,7 @@ class BrokeredMessage
     /**
      * Gets the reply to session ID.
      *
-     * @return string
+     * @return string|null
      */
     public function getReplyToSessionId()
     {
@@ -461,7 +461,7 @@ class BrokeredMessage
     /**
      * Sets the reply to session ID.
      *
-     * @param string $replyToSessionId The session ID of the reply to recipient
+     * @param string|null $replyToSessionId The session ID of the reply to recipient
      */
     public function setReplyToSessionId($replyToSessionId)
     {
@@ -471,7 +471,7 @@ class BrokeredMessage
     /**
      * Gets the message location.
      *
-     * @return string
+     * @return string|null
      */
     public function getMessageLocation()
     {
@@ -481,7 +481,7 @@ class BrokeredMessage
     /**
      * Sets the message location.
      *
-     * @param string $messageLocation The location of the message
+     * @param string|null $messageLocation The location of the message
      */
     public function setMessageLocation($messageLocation)
     {
@@ -491,7 +491,7 @@ class BrokeredMessage
     /**
      * Gets the location of the lock.
      *
-     * @return string
+     * @return string|null
      */
     public function getLockLocation()
     {
@@ -501,7 +501,7 @@ class BrokeredMessage
     /**
      * Sets the location of the lock.
      *
-     * @param string $lockLocation The location of the lock
+     * @param string|null $lockLocation The location of the lock
      */
     public function setLockLocation($lockLocation)
     {

--- a/src/ServiceBus/ServiceBusRestProxy.php
+++ b/src/ServiceBus/ServiceBusRestProxy.php
@@ -160,7 +160,7 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
      * @param ReceiveMessageOptions|null $receiveMessageOptions The options to
      *                                                          receive the message
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveQueueMessage(
         $queueName,
@@ -193,7 +193,7 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
      * @param ReceiveMessageOptions $receiveMessageOptions The options to
      *                                                     receive the message
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveMessage($path, ReceiveMessageOptions $receiveMessageOptions = null)
     {
@@ -293,7 +293,7 @@ class ServiceBusRestProxy extends ServiceRestProxy implements IServiceBus
      * @param ReceiveMessageOptions|null $receiveMessageOptions The options to
      *                                                          receive the subscription message
      *
-     * @return BrokeredMessage
+     * @return BrokeredMessage|null
      */
     public function receiveSubscriptionMessage(
         $topicName,


### PR DESCRIPTION
- In ServiceBusRestProxy: fix phpdoc @return : receiveMessage() receiveQueueMessage() and receiveSubscriptionMessage() can return null.

https://github.com/Azure/azure-sdk-for-php/blob/83225de92de1a9b9325e59bd58bc143d3df505e6/src/ServiceBus/ServiceBusRestProxy.php#L226

- In BrokerProperties, by default, when initiate an instance of the class, all properties are unset, so they are null. Fixing Phpdoc for properties, getters and setters
- In BrokeredMessage, also some phpdoc type fixes